### PR TITLE
Added group to resources

### DIFF
--- a/app/config/sylius.yml
+++ b/app/config/sylius.yml
@@ -99,3 +99,7 @@ sylius_resource:
                 model: Sylius\Bundle\CoreBundle\Model\User
                 controller: Sylius\Bundle\CoreBundle\Controller\UserController
                 repository: Sylius\Bundle\CoreBundle\Repository\UserRepository
+        sylius.group:
+            driver: doctrine/orm
+            classes:
+                model: Sylius\Bundle\CoreBundle\Model\Group


### PR DESCRIPTION
When you load the fixtures, you get the error:

```
You have requested a non-existent service "sylius.repository.group".
```

This PR adds group to resources like in sylius project
