### PR TITLE
Fix omnipay/omnipay requirement again

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2428,12 +2428,12 @@
             "version": "v1.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/adrianmacneil/omnipay.git",
+                "url": "https://github.com/omnipay/omnipay.git",
                 "reference": "4f5e82232161939c0b14f5921c092ed77980d450"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/adrianmacneil/omnipay/zipball/4f5e82232161939c0b14f5921c092ed77980d450",
+                "url": "https://api.github.com/repos/omnipay/omnipay/zipball/4f5e82232161939c0b14f5921c092ed77980d450",
                 "reference": "4f5e82232161939c0b14f5921c092ed77980d450",
                 "shasum": ""
             },
@@ -2467,7 +2467,7 @@
                 }
             ],
             "description": "A framework agnostic, multi-gateway payment processing library",
-            "homepage": "https://github.com/adrianmacneil/omnipay",
+            "homepage": "https://github.com/omnipay/omnipay",
             "keywords": [
                 "2checkout",
                 "2co",


### PR DESCRIPTION
Fixed the omnipay/omnipay requirement agian, like in PR #20 because PR #23 reversed it.

Maybe it's better to remove the `composer.lock`? I thought Sylius-Standard should be a skeleton like symfony-standard, so when I create a project via composer I should not depend on locked vendors. It should install always the latest vendors.
