### PR TITLE
Update sylius.yml

### DIFF
--- a/app/config/sylius.yml
+++ b/app/config/sylius.yml
@@ -64,7 +64,7 @@ sylius_promotions: ~
 sylius_inventory:
     backorders: true
     classes:
-        unit:
+        inventory_unit:
             model: Sylius\Bundle\CoreBundle\Model\InventoryUnit
         stockable:
             model: %sylius.model.variant.class%


### PR DESCRIPTION
Changed unit to inventory_unit in the sylius_inventory config settings to correct the "Unrecognized options" error when running the installer.
