### PR TITLE
Allow bundles to extends sylius parameters

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -13,6 +13,6 @@ class AppKernel extends Kernel
         $bundles = array(
         );
 
-        return array_merge($bundles, parent::registerBundles());
+        return array_merge(parent::registerBundles(), $bundles);
     }
 }


### PR DESCRIPTION
This PR allow src Bundles to override parameters defined in SyliusBundles as they are now loaded before. 
