### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,8 @@
         "white-october/pagerfanta-bundle":      "@dev",
         "friendsofsymfony/oauth-server-bundle": "@dev",
         "willdurand/hateoas-bundle":            "1.0.*@dev",
-        "jms/serializer-bundle":                "0.13.*@dev"
+        "jms/serializer-bundle":                "0.13.*@dev",
+        "friendsofsymfony/rest-bundle":         "1.5.*@dev"
     },
     "require-dev": {
         "behat/behat":                       "~3.0",


### PR DESCRIPTION
It's a temporary workaround as firendsofsymfony/rest-bundle 1.5 is not released yet.
Maybe a patch directly in the sylius/sylius repo will be better ?

The version is forced by "symfony-cmf/create-bundle" which require ~1.0 version while sylius require ~1.0@dev.

@pjedrzejewski Is 1.5@dev really needed by sylius ?