### PR TITLE
Added missing wkhtmltopdf & wkhtmltoimage parameters

### DIFF
--- a/app/config/parameters.yml.dist
+++ b/app/config/parameters.yml.dist
@@ -63,3 +63,6 @@ parameters:
 
     sylius.order.allow_guest_order: false
     sylius.order.pending.duration: 3 hours
+    
+    wkhtmltopdf.bin_path: /usr/bin/wkhtmltopdf
+    wkhtmltoimage.bin_path: /usr/bin/wkhtmltoimage


### PR DESCRIPTION
Added the `wkhtmltopdf.bin_path` & `wkhtmltoimage.bin_path` parameters as defined in https://github.com/Sylius/Sylius/blob/master/app/config/parameters.yml.dist#L69. 