### PR TITLE
Session handler config fix

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -15,7 +15,9 @@ framework:
     templating:      { engines: ['twig'] }
     default_locale:  "%sylius.locale%"
     trusted_proxies: ~
-    session:         ~
+    session:
+        # handler_id set to null will use default session handler from php.ini
+        handler_id:  ~
 
 twig:
     form:


### PR DESCRIPTION
Same as symfony-standard (https://github.com/symfony/symfony-standard/blob/2.8/app/config/config.yml#L30). 

Fixes https://github.com/Sylius/Sylius/issues/2585. 