### PR TITLE
[Travis] Enable PHP 7.1 for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ env:
 sudo: required
 
 php:
-    - 7.0
+    - 7.1
     - 5.6
 
 services:


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no |
| New feature?    | no |
| BC breaks?      | no |

PHP 7.1 was released yesterday, so I think it's about time to run the test suite against it 🎉 

Build is failing for 7.1 because of `Warning: A non-numeric value encountered  in ...` which is fixed in https://github.com/Sylius/Sylius/pull/6757