### PR TITLE
[Maintenance] [DX] Improve migration handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
 before_script:
     - bin/console doctrine:database:create --env=test_cached -vvv # Have to be run with debug = true, to omit generating proxies before setting up the database
     - bin/console cache:warmup --env=test_cached --no-debug -vvv
-    - bin/console doctrine:migrations:migrate --no-interaction --env=test_cached --no-debug -vvv
+    - bin/console doctrine:migrations:migrate --configuration app/config/sylius_migration.yml --no-interaction --env=test_cached --no-debug -vvv
 
     - bin/console assets:install --env=test_cached --no-debug -vvv
     - npm run gulp

--- a/app/config/sylius_migration.yml
+++ b/app/config/sylius_migration.yml
@@ -1,0 +1,7 @@
+# This file is part of the Sylius package.
+# (c) Paweł Jędrzejewski
+
+name: Sylius Migrations
+migrations_namespace: Sylius\Migrations
+table_name: sylius_migrations
+migrations_directory: "vendor/sylius/sylius/app/migrations/"


### PR DESCRIPTION
As I mention in [this comment](https://github.com/Sylius/Sylius-Standard/pull/157#issuecomment-276076814) with this file it will be much easier to run Sylius Migrations. It would be enough to execute the following command:
```bash
$ php app/console doctrine:migration:migrate --configuration app/config/sylius_migration.yml
```
instead of copy-pasting the whole migration folder. 