### PR TITLE
[BugFix] Add getContainerLoader method to AppKernel

### DIFF
--- a/app/AppKernel.php
+++ b/app/AppKernel.php
@@ -10,10 +10,21 @@
  */
 
 use Sylius\Bundle\CoreBundle\Application\Kernel;
+use Symfony\Component\Config\Loader\DelegatingLoader;
+use Symfony\Component\Config\Loader\LoaderResolver;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\DependencyInjection\Loader\ClosureLoader;
+use Symfony\Component\DependencyInjection\Loader\DirectoryLoader;
+use Symfony\Component\DependencyInjection\Loader\IniFileLoader;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
+use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
+use Symfony\Component\HttpKernel\Config\FileLocator;
 
 /**
  * @author Paweł Jędrzejewski <pawel@sylius.org>
  * @author Gonzalo Vilaseca <gvilaseca@reiss.co.uk>
+ * @author Magdalena Banasiak <magdalena.banasiak@lakion.com>
  */
 class AppKernel extends Kernel
 {
@@ -33,5 +44,23 @@ class AppKernel extends Kernel
         ];
 
         return array_merge(parent::registerBundles(), $bundles);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getContainerLoader(ContainerInterface $container)
+    {
+        $locator = new FileLocator($this, $this->getRootDir() . '/Resources');
+        $resolver = new LoaderResolver(array(
+            new XmlFileLoader($container, $locator),
+            new YamlFileLoader($container, $locator),
+            new IniFileLoader($container, $locator),
+            new PhpFileLoader($container, $locator),
+            new DirectoryLoader($container, $locator),
+            new ClosureLoader($container),
+        ));
+
+        return new DelegatingLoader($resolver);
     }
 }


### PR DESCRIPTION
It is a solution to https://github.com/Sylius/Sylius/issues/7095;

Prepared basing on this comment: https://github.com/Sylius/Sylius/issues/7095#issuecomment-268904810

Having such a `getContainerLoader` method [this guide](http://docs.sylius.org/en/latest/cookbook/checkout.html#overwrite-the-state-machine-of-checkout) works properly.