### PR TITLE
Add server:start pid file to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /app/config/*.local.yml
 /var/*
 !/var/.gitkeep
+/.web-server-pid
 
 /web/assets
 /web/bundles


### PR DESCRIPTION
As described in the readme file, server:start should be used to start a webserver for Sylius.
This will make the command create a .web-server-pid file, which is not covered by .gitignore.