### PR TITLE
Fix Docker image build order

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,6 +84,7 @@ services:
     image: quay.io/sylius/nginx:latest
     depends_on:
       - php
+      - nodejs # to ensure correct build order
     volumes:
       - ./docker/nginx/conf.d/default.dev.conf:/etc/nginx/conf.d/default.conf
       - ./web:/srv/sylius/web:ro


### PR DESCRIPTION
The correct build order is important for proper Docker layer caching.