### PR TITLE
Using symfony/flex to clear legacy tags, which reduces memory usage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require": {
         "php": "^7.2",
         "sylius/sylius": "1.3.*@dev",
+        "symfony/flex": "^1.1",
         "symfony/symfony": "^3.4|^4.1"
     },
     "require-dev": {
@@ -74,6 +75,9 @@
         "sort-packages": true
     },
     "extra": {
+        "symfony": {
+            "require": "^3.4|^4.1"
+        },
         "symfony-app-dir": "app",
         "symfony-bin-dir": "bin",
         "symfony-var-dir": "var",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "8cfea0df1227483798340479506a224b",
+    "content-hash": "c64ef2568e11c0f8bb199da152469d94",
     "packages": [
         {
             "name": "behat/transliterator",
@@ -5817,6 +5817,53 @@
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
             "time": "2018-07-26T11:19:56+00:00"
+        },
+        {
+            "name": "symfony/flex",
+            "version": "v1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/flex.git",
+                "reference": "d6f5fed47ddad2eb25d5cc19316692203a2898eb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/d6f5fed47ddad2eb25d5cc19316692203a2898eb",
+                "reference": "d6f5fed47ddad2eb25d5cc19316692203a2898eb",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0",
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2",
+                "symfony/phpunit-bridge": "^3.2.8"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                },
+                "class": "Symfony\\Flex\\Flex"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Flex\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien.potencier@gmail.com"
+                }
+            ],
+            "description": "Composer plugin for Symfony",
+            "time": "2018-08-21T07:51:18+00:00"
         },
         {
             "name": "symfony/monolog-bundle",

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,0 +1,11 @@
+{
+    "symfony/flex": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "e921bdbfe20cdefa3b82f379d1cd36df1bc8d115"
+        }
+    }
+}


### PR DESCRIPTION
Memory and CPU time.

See: https://github.com/composer/composer/issues/7577

Before: Memory usage: 397MB (peak: 1569.52MB), time: 31.17s
After: Memory usage: 230.92MB (peak: 263.72MB), time: 5.78s