### PR TITLE
Fix: add coreutils to build-deps to be able to use nproc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ ARG APCU_VERSION=5.1.11
 RUN set -eux; \
 	apk add --no-cache --virtual .build-deps \
 		$PHPIZE_DEPS \
+		coreutils \
 		freetype-dev \
 		icu-dev \
 		libjpeg-turbo-dev \


### PR DESCRIPTION
When building the `php` image, the following error appears:
```shell
+ nproc
/bin/sh: nproc: not found
+ docker-php-ext-install -j exif gd intl pdo_mysql zip
make: the '-j' option requires a positive integer argument
```
It's because `nproc` is not available in the `php-fpm-alpine` image but can be found in the `coreutils` package: https://pkgs.alpinelinux.org/contents?file=nproc&path=&name=&branch=edge
I've added it to the `build-deps` in order to fix it.