### PR TITLE
Only change php memory_limit in dev for Docker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - PHP_DATE_TIMEZONE=${PHP_DATE_TIMEZONE:-UTC}
     volumes:
       - .:/srv/sylius:rw,cached
+      - ./docker/php/php-cli.dev.ini:/usr/local/etc/php/php-cli.ini
       # if you develop on Linux, you may use a bind-mounted host directory instead
       # - ./var:/srv/sylius/var:rw
       - ./public:/srv/sylius/public:rw,delegated

--- a/docker/php/php-cli.dev.ini
+++ b/docker/php/php-cli.dev.ini
@@ -10,3 +10,5 @@ opcache.max_accelerated_files = 20000
 opcache.memory_consumption = 256
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
+
+memory_limit = 2G


### PR DESCRIPTION
| Q               | A
| --------------- | -----
| Branch?         | 1.3 (or master?)
| Bug fix?        | no
| New feature?    | no?
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | N/A
| License         | MIT

Because memory usage should be under control in `prod`.