### PR TITLE
Wrong dev package placement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require": {
         "php": "^7.2",
         "sylius/sylius": "~1.3.0",
-        "symfony/flex": "^1.1"
+        "symfony/flex": "^1.1",
+        "sensiolabs/security-checker": "^5.0"
     },
     "require-dev": {
         "behat/behat": "^3.4",
@@ -38,7 +39,6 @@
         "lakion/mink-debug-extension": "^1.2.3",
         "phpspec/phpspec": "^5.0",
         "phpunit/phpunit": "^6.5",
-        "sensiolabs/security-checker": "^5.0",
         "stripe/stripe-php": "^4.1",
         "sylius-labs/coding-standard": "^2.0",
         "symfony/browser-kit": "^3.4|^4.1",


### PR DESCRIPTION
`sensiolabs/security-checker` is needed for `auto-scripts` so when you put it in production you will get errors because this package does not exists.

Bug #296