### PR TITLE
[Composer] Add showing plugins command after creating a new project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
+        ],
+        "post-create-project-cmd": [
+            "bin/console sylius:show-available-plugins --ansi"
         ]
     },
     "config": {


### PR DESCRIPTION
Waiting for https://github.com/Sylius/Sylius/pull/10004 and for Sylius 1.3.6

![image](https://user-images.githubusercontent.com/6140884/49527667-b1767e00-f8b2-11e8-913e-40425e0f59bb.png)
