### PR TITLE
Fix container cleanup when it's a ResetInterface

### DIFF
--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -178,6 +178,6 @@ final class Kernel extends BaseKernel
             }
         }
 
-        $containerServicesPropertyReflection->setValue($container, null);
+        $containerServicesPropertyReflection->setValue($container, []);
     }
 }


### PR DESCRIPTION
When the container is `instanceof ResetInterface` for exemple while using PHPUnit the `cleanupContainer` will reset the `$container->services` to `null` but in `Symfony\Bundle\FrameworkBundle\Test::ensureKernelShutdown()` the method `$container->reset()` is called and when it try to execute the first line of this method : `$services = $this->services + $this->privates;` `$this->services` is `null` instead of being an empty `array`.