### PR TITLE
set sql_mode to empty string in docker composer setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,7 @@ services:
       - MYSQL_DATABASE=sylius
       - MYSQL_USER=sylius
       - MYSQL_PASSWORD=${MYSQL_PASSWORD:-nopassword}
+    command: mysqld --sql_mode=""
     volumes:
       - mysql-data:/var/lib/mysql:rw
       # you may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!


### PR DESCRIPTION
work around for https://github.com/Sylius/Sylius/issues/7389

ie. without it using the standard fixtures on http://localhost/en_US/taxons/mugs I get:
```
SQLSTATE[HY000]: General error: 3065 Expression #1 of ORDER BY clause is not in SELECT list, references column 'sylius.s2_.position' which is not in SELECT list; this is incompatible with DISTINCT
```