### PR TITLE
[RFC] Do not force to use annotations for Sylius project

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -18,7 +18,91 @@ doctrine:
         mappings:
             App:
                 is_bundle: false
-                type: annotation
-                dir: '%kernel.project_dir%/src/Entity'
-                prefix: 'App\Entity'
+                type: yml
+                dir: '%kernel.project_dir%/src/Resources/config/doctrine'
+                prefix: 'App\Entity\Main'
                 alias: App
+            SyliusAddressing:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Addressing'
+                prefix: 'App\Entity\Addressing'
+                alias: SyliusAddressing
+            SyliusAdminApi:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/AdminApi'
+                prefix: 'App\Entity\AdminApi'
+                alias: SyliusAdminApi
+            SyliusChannel:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Channel'
+                prefix: 'App\Entity\Channel'
+                alias: SyliusChannel
+            SyliusCurrency:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Currency'
+                prefix: 'App\Entity\Currency'
+                alias: SyliusCurrency
+            SyliusCustomer:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Customer'
+                prefix: 'App\Entity\Customer'
+                alias: SyliusCustomer
+            SyliusLocale:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Locale'
+                prefix: 'App\Entity\Locale'
+                alias: SyliusLocale
+            SyliusOrder:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Order'
+                prefix: 'App\Entity\Order'
+                alias: SyliusOrder
+            SyliusPayment:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Payment'
+                prefix: 'App\Entity\Payment'
+                alias: SyliusPayment
+            SyliusProduct:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Product'
+                prefix: 'App\Entity\Product'
+                alias: SyliusProduct
+            SyliusPromotion:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Promotion'
+                prefix: 'App\Entity\Promotion'
+                alias: SyliusPromotion
+            SyliusShipping:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Shipping'
+                prefix: 'App\Entity\Shipping'
+                alias: SyliusShipping
+            SyliusTaxation:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Taxation'
+                prefix: 'App\Entity\Taxation'
+                alias: SyliusTaxation
+            SyliusTaxonomy:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Taxonomy'
+                prefix: 'App\Entity\Taxonomy'
+                alias: SyliusTaxonomy
+            SyliusUser:
+                is_bundle: false
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/User'
+                prefix: 'App\Entity\User'
+                alias: SyliusUser

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -18,8 +18,8 @@ doctrine:
         mappings:
             App:
                 is_bundle: false
-                type: yml
-                dir: '%kernel.project_dir%/src/Resources/config/doctrine'
+                type: annotation
+                dir: '%kernel.project_dir%/src/Entity/Main'
                 prefix: 'App\Entity\Main'
                 alias: App
             SyliusAddressing:


### PR DESCRIPTION
I open this PR as a base for a discussion about default orm mapping in Sylius-Standard.

Right now we have all **Sylius** entities extended by default in `src/Entity/` directory and mapped with annotations mapping - which is correct and useful, as we have no better option to extend **Sylius** entities in plugins than [providing a trait with new properties, including their mapping](https://github.com/Sylius/Sylius/issues/9214). So with such a configuration installing a plugin and extending a **Sylius** entity is quite hassle-free.

#### HOWEVER

I, personally, feel bad that I'm a little bit *forced* to use annotations (I **really** prefer `yml` or, even better, `xml` mapping). I know, I'm not the only one, even though there are not so many of us nowadays 🏝 👴 When I create my own, new resource, in `src/Entity/` directory, I'm not able to change the mapping type that I hate, without changing it for all other entities. I was struggling with this issue, as I don't want to force anyone to follow my rules, but on the other hand, I don't want to be forced to anything neither 🚀 Moreover, a doctrine mapping configuration is not so smart and we cannot define any rule like "use _this_ mapping  or, if it's not defined, use _this_ instead" 😢 The only way to differentiate mappings is to separate entities into subdirectories and configure mapping for them.

As a first proposal, I wanted to move all **Sylius** entities to `src/Entity/Sylius` and create another `src/Entity/Main` directory with different configurations. I found it kinda weird, so I propose a separate configuration for each _pack of entities_ and another one for a `src/Entity/Main` (name _to be refactored_), as a directory for custom entities.

I don't know is it the best solution. More, I don't even know if maybe it's my imagined problem 😄 But I would love to see an opinion of others @Sylius/core-team members and, of course, from our beloved community 🎉 

Live long and prosper 🖖 ☮️ 