### PR TITLE
[Composer] Update path to PHP binary in scripts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -71,8 +71,8 @@
             "@auto-scripts"
         ],
         "post-create-project-cmd": [
-            "php bin/console sylius:inform-about-gus",
-            "php bin/console sylius:show-available-plugins --ansi"
+            "@php bin/console sylius:inform-about-gus",
+            "@php bin/console sylius:show-available-plugins --ansi"
         ]
     },
     "config": {


### PR DESCRIPTION
Using [@php](https://getcomposer.org/doc/articles/scripts.md#executing-php-scripts) in composer.json to resolve in a path to the PHP process is currently being used.
Resolve issues in the environments where are multiple PHP versions used.