### PR TITLE
Synchronize security.yaml with Sylius/Sylius

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -4,6 +4,7 @@ parameters:
     sylius.security.shop_regex: "^/(?!admin|api/.*|api$|media/.*)[^/]++"
 
 security:
+    always_authenticate_before_granting: true
     providers:
         sylius_admin_user_provider:
             id: sylius.admin_user_provider.email_or_name_based
@@ -29,7 +30,7 @@ security:
                 csrf_parameter: _csrf_admin_security_token
                 csrf_token_id: admin_authenticate
             remember_me:
-                secret: '%kernel.secret%'
+                secret: "%env(APP_SECRET)%"
                 path: /admin
                 name: APP_ADMIN_REMEMBER_ME
                 lifetime: 31536000
@@ -69,7 +70,7 @@ security:
                 csrf_parameter: _csrf_shop_security_token
                 csrf_token_id: shop_authenticate
             remember_me:
-                secret: '%kernel.secret%'
+                secret: "%env(APP_SECRET)%"
                 name: APP_SHOP_REMEMBER_ME
                 lifetime: 31536000
                 remember_me_parameter: _remember_me


### PR DESCRIPTION
The same should be done for `1.4`, I believe it can be a problem for not being able to log in to the administration panel just after the installation (but I've checked it on `1.4`, so I don't know does it happen also for `1.3`):

<img width="1049" alt="Screenshot 2019-05-09 at 11 40 10" src="https://user-images.githubusercontent.com/6212718/57443841-38a79380-724f-11e9-8409-172ab88eccd2.png">
