### PR TITLE
Don't mount mailhog maildir directory from host

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,8 +88,8 @@ services:
     image: mailhog/mailhog:latest
     environment:
       - MH_STORAGE=maildir
-    volumes:
-      - ./docker/mailhog/maildir:/maildir:rw,delegated
+    # volumes:
+    #   - ./docker/mailhog/maildir:/maildir:rw,delegated
     ports:
       - "8025:8025"
 


### PR DESCRIPTION
Avoid problem with permissions as the mailhog container does not run as root