### PR TITLE
[Config] Add missing media image folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /public/css
 /public/js
 /public/media
+!/public/media/image/.gitkeep
 
 /node_modules
 


### PR DESCRIPTION
On fresh copy, there are no ability to list commands and run some other commands until sylius:install will be executed (which will create public/media/image directory)

Ref. https://github.com/Sylius/Sylius/pull/9961