### PR TITLE
Update platform php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.3.14"
+            "php": "7.3.13"
         },
         "preferred-install": {
             "*": "dist"

--- a/composer.json
+++ b/composer.json
@@ -78,7 +78,7 @@
     },
     "config": {
         "platform": {
-            "php": "7.2"
+            "php": "7.3.14"
         },
         "preferred-install": {
             "*": "dist"


### PR DESCRIPTION
Its bad to use here 7.2 or 7.3 as this will force the php version to 7.2.0 ([reference](https://github.com/composer/composer/issues/8144)). For example if a package requires in a newer version `^7.2.1` you will not get the newest version of it, so if make usage of the config.platform.php it should use the 3 digit version.