### PR TITLE
Remove existing queries in last migration

### DIFF
--- a/src/Migrations/Version20200301170604.php
+++ b/src/Migrations/Version20200301170604.php
@@ -22,13 +22,7 @@ final class Version20200301170604 extends AbstractMigration
         // this up() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('CREATE TABLE sylius_channel_countries (channel_id INT NOT NULL, country_id INT NOT NULL, INDEX IDX_D96E51AE72F5A1AA (channel_id), INDEX IDX_D96E51AEF92F3E70 (country_id), PRIMARY KEY(channel_id, country_id)) DEFAULT CHARACTER SET UTF8 COLLATE `UTF8_unicode_ci` ENGINE = InnoDB');
-        $this->addSql('ALTER TABLE sylius_channel_countries ADD CONSTRAINT FK_D96E51AE72F5A1AA FOREIGN KEY (channel_id) REFERENCES sylius_channel (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE sylius_channel_countries ADD CONSTRAINT FK_D96E51AEF92F3E70 FOREIGN KEY (country_id) REFERENCES sylius_country (id) ON DELETE CASCADE');
-        $this->addSql('ALTER TABLE sylius_shipment ADD shipped_at DATETIME DEFAULT NULL');
-        $this->addSql('ALTER TABLE sylius_channel ADD menu_taxon_id INT DEFAULT NULL, DROP type');
-        $this->addSql('ALTER TABLE sylius_channel ADD CONSTRAINT FK_16C8119EF242B1E6 FOREIGN KEY (menu_taxon_id) REFERENCES sylius_taxon (id) ON DELETE SET NULL');
-        $this->addSql('CREATE INDEX IDX_16C8119EF242B1E6 ON sylius_channel (menu_taxon_id)');
+        $this->addSql('ALTER TABLE sylius_channel DROP type');
     }
 
     public function down(Schema $schema): void
@@ -36,10 +30,6 @@ final class Version20200301170604 extends AbstractMigration
         // this down() migration is auto-generated, please modify it to your needs
         $this->abortIf($this->connection->getDatabasePlatform()->getName() !== 'mysql', 'Migration can only be executed safely on \'mysql\'.');
 
-        $this->addSql('DROP TABLE sylius_channel_countries');
-        $this->addSql('ALTER TABLE sylius_channel DROP FOREIGN KEY FK_16C8119EF242B1E6');
-        $this->addSql('DROP INDEX IDX_16C8119EF242B1E6 ON sylius_channel');
-        $this->addSql('ALTER TABLE sylius_channel ADD type VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`, DROP menu_taxon_id');
-        $this->addSql('ALTER TABLE sylius_shipment DROP shipped_at');
+        $this->addSql('ALTER TABLE sylius_channel ADD type VARCHAR(255) CHARACTER SET utf8 DEFAULT NULL COLLATE `utf8_unicode_ci`');
     }
 }


### PR DESCRIPTION
Last migration already contains a lot a previous queries.

- Line 25 to 27 are in `Version20200122082429.php`
- Line 28 is in `Version20200202104152.php`
- Line 29 to 31 are in `Version20200110132702.php` (except they don't drop `type`) 
