### PR TITLE
Docker Compose: prevent MySQL's mbind errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,8 @@ services:
       # - ./docker/mysql/data:/var/lib/mysql:rw,delegated
     ports:
       - "${MYSQL_PORT:-3306}:3306"
+    cap_add:
+      - SYS_NICE # prevent "mbind: Operation not permitted" errors
 
   node:
     container_name: node


### PR DESCRIPTION
Prevent `mbind: Operation not permitted` errors from polluting the logs.