### PR TITLE
[CI] Switch from ubuntu-latest to ubuntu-18.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
     tests:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
 
         name: "PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }}, MySQL ${{ matrix.mysql }}"
 


### PR DESCRIPTION
In the coming weeks, ubuntu-latest will start pointing to ubuntu-20.04 instead of ubuntu-18.04. Let's prevent potential failures by specifying directly ubuntu-18.04 for now and consiously upgrading to ubuntu-20.04 when we're ready - possibly after dropping PHP 7.3 compatibility, since setting it up on the newer version of Ubuntu takes a lot more time.

Ref: https://github.com/actions/virtual-environments/issues/1816