### PR TITLE
Auto-merge dependabot PRs with Github Actions

### DIFF
--- a/.github/auto-merge.yml
+++ b/.github/auto-merge.yml
@@ -1,8 +1,0 @@
-requiredLabels:
-    - Dependencies
-
-deleteBranchAfterMerge: true
-
-requiredBaseBranches:
-    - master
-    - 1.8

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto-merge
+
+on:
+    pull_request: ~
+
+jobs:
+    auto-merge:
+        runs-on: ubuntu-18.04
+        steps:
+            -   uses: actions/checkout@v2
+
+            -
+                name: Auto-merge minor dependencies upgrades
+                uses: ahmadnassri/action-dependabot-auto-merge@v2
+                with:
+                    target: minor
+                    github-token: ${{ secrets.DEPENDABOT_TOKEN }}


### PR DESCRIPTION
Using this action has some strong advantages over the previous bot:

* detects Dependabot PRs automatically (relying on the label name is a little bit silly approach)
* automatically approve PRs if it fulfils the requirements
* we're able to configure that only minor upgrades would be merged

🤞 it will work 🚀 