### PR TITLE
[CI] Add --no-check-publish to Composer validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
 
             -   
                 name: Validate composer.json
-                run: composer validate --ansi --strict
+                run: composer validate --ansi --strict --no-check-publish
                 
             -   
                 name: Run security check


### PR DESCRIPTION
Apps based on Sylius-Standard are not published anyway.