### PR TITLE
Add serialization mapping to framework.yaml

### DIFF
--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -5,3 +5,6 @@ framework:
     csrf_protection: true
     session:
         handler_id: ~
+    serializer:
+        mapping:
+            paths: [ '%kernel.project_dir%/config/serialization' ]


### PR DESCRIPTION
This would become necessary if someone would like to modify serialization for api.