### PR TITLE
Speed up php-fpm container on MacOS

### DIFF
--- a/.env
+++ b/.env
@@ -12,7 +12,7 @@ APP_SECRET=EDITME
 # Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
 # For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
 # Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%
+DATABASE_URL=mysql://sylius:nopassword@mysql/sylius
 ###< doctrine/doctrine-bundle ###
 
 ###> symfony/swiftmailer-bundle ###

--- a/README.md
+++ b/README.md
@@ -38,6 +38,36 @@ $ php bin/console server:start
 $ open http://localhost:8000/
 ```
 
+### For Docker installation
+
+```bash
+$ docker-compose up -d
+$ docker-compose run php php bin/console sylius:install
+$ open http://localhost/
+```
+
+> You may check if php-fpm is running just execution `docker-composer ps`
+
+If the pages not load the assets, just run the below commands:
+
+```bash
+$ docker-compose run nodejs yarn install
+$ docker-compose run nodejs yarn build
+```
+
+#### For MacOS Docker
+
+You need must enable the NFS (Network File System) to speed up your experience.
+
+```bash
+$ sh setup_native_nfs_docker_osx.sh
+```
+
+So, just append the NFS configuration using the command:
+```bash
+$ docker-compose -f docker-compose.yml -f docker-compose-nfs.yml up -d
+```
+
 Troubleshooting
 ---------------
 

--- a/docker-compose-nfs.yml
+++ b/docker-compose-nfs.yml
@@ -1,0 +1,30 @@
+version: '3.4'
+
+services:
+  php:
+      volumes:
+      - sylius-nfs:/srv/sylius:rw,delegated
+      - public-nfs:/srv/sylius/public:rw,delegated
+      - public-media:/srv/sylius/public/media:rw,delegated
+  nodejs:
+      volumes:
+      - sylius-nfs:/srv/sylius:delegated
+      - public-nfs:/srv/sylius/public:rw,delegated
+  nginx:
+      volumes:
+      - sylius-nfs:/srv/sylius:cached
+      - public-media:/srv/sylius/public/media:ro,nocopy
+
+volumes:
+  sylius-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${PWD}
+  public-nfs:
+    driver: local
+    driver_opts:
+      type: nfs
+      o: addr=host.docker.internal,rw,nolock,hard,nointr,nfsvers=3
+      device: :${PWD}/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,24 @@
 version: '3.4'
 
+x-cache-from:
+    - &sylius-cache-from
+        cache_from:
+            - ${NGINX_IMAGE:-nginx:latest}
+            - ${PHP_IMAGE:-php:latest}
+            - ${NODEJS_IMAGE:-node:latest}
+
 services:
   php:
     build:
       context: .
       target: sylius_php
-      cache_from:
-        - quay.io/sylius/php:latest
-        - quay.io/sylius/nodejs:latest
-        - quay.io/sylius/nginx:latest
-    image: quay.io/sylius/php:latest
+      <<: *sylius-cache-from
+    image: ${PHP_IMAGE:-php:latest}
+    healthcheck:
+        interval: 10s
+        timeout: 3s
+        retries: 3
+        start_period: 30s
     depends_on:
       - mysql
     environment:
@@ -46,11 +55,8 @@ services:
     build:
       context: .
       target: sylius_nodejs
-      cache_from:
-        - quay.io/sylius/php:latest
-        - quay.io/sylius/nodejs:latest
-        - quay.io/sylius/nginx:latest
-    image: quay.io/sylius/nodejs:latest
+      <<: *sylius-cache-from
+    image: ${NODEJS_IMAGE:-node:latest}
     depends_on:
       - php
     environment:
@@ -67,11 +73,8 @@ services:
     build:
       context: .
       target: sylius_nginx
-      cache_from:
-        - quay.io/sylius/php:latest
-        - quay.io/sylius/nodejs:latest
-        - quay.io/sylius/nginx:latest
-    image: quay.io/sylius/nginx:latest
+      <<: *sylius-cache-from
+    image: ${NGINX_IMAGE:-nginx:latest}
     depends_on:
       - php
       - nodejs # to ensure correct build order

--- a/docker/nginx/conf.d/default.conf
+++ b/docker/nginx/conf.d/default.conf
@@ -1,5 +1,6 @@
 server {
     root /srv/sylius/public;
+    listen *:80;
 
     location / {
         # try to serve file directly, fallback to index.php

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -7,16 +7,6 @@ if [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
-	mkdir -p var/cache var/log public/media
-	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media
-	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media
-
-	if [ "$APP_ENV" != 'prod' ]; then
-		composer install --prefer-dist --no-progress --no-suggest --no-interaction
-		bin/console assets:install --no-interaction
-		bin/console sylius:theme:assets:install public --no-interaction
-	fi
-
 	until bin/console doctrine:query:sql "select 1" >/dev/null 2>&1; do
 	    (>&2 echo "Waiting for MySQL to be ready...")
 		sleep 1

--- a/docker/php/docker-healthcheck.sh
+++ b/docker/php/docker-healthcheck.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+export SCRIPT_NAME=/ping
+export SCRIPT_FILENAME=/ping
+export REQUEST_METHOD=GET
+
+if cgi-fcgi -bind -connect 127.0.0.1:9000; then
+	exit 0
+fi
+
+exit 1

--- a/docker/php/php-cli.ini
+++ b/docker/php/php-cli.ini
@@ -1,15 +1,19 @@
 apc.enable_cli = 1
 date.timezone = ${PHP_DATE_TIMEZONE}
-opcache.enable_cli = 1
 session.auto_start = Off
 short_open_tag = Off
 
 # http://symfony.com/doc/current/performance.html
+opcache.enable=1
+opcache.enable_cli = 1
+opcache.fast_shutdown=1
 opcache.interned_strings_buffer = 16
-opcache.max_accelerated_files = 20000
+opcache.max_accelerated_files = 524521
 opcache.memory_consumption = 256
-realpath_cache_size = 4096K
-realpath_cache_ttl = 600
+opcache.revalidate_freq=0
+opcache.validate_timestamps=0
+opcache.enable_file_override=0
+opcache.error_log=/var/log/php-opcache-error.log
 
 memory_limit = 2G
 post_max_size = 6M

--- a/docker/php/php.ini
+++ b/docker/php/php.ini
@@ -1,13 +1,20 @@
 apc.enable_cli = 1
 date.timezone = ${PHP_DATE_TIMEZONE}
-opcache.enable_cli = 1
 session.auto_start = Off
 short_open_tag = Off
 
 # http://symfony.com/doc/current/performance.html
+opcache.enable=1
+opcache.enable_cli = 1
+opcache.enable_file_override=0
+opcache.error_log=/var/log/php-opcache-error.log
+opcache.fast_shutdown=1
 opcache.interned_strings_buffer = 16
-opcache.max_accelerated_files = 20000
+opcache.max_accelerated_files = 524521
 opcache.memory_consumption = 256
+opcache.revalidate_freq=0
+opcache.validate_timestamps=0
+
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
 

--- a/docker/php/sylius.conf
+++ b/docker/php/sylius.conf
@@ -1,0 +1,14 @@
+[www]
+user = www-data
+group = www-data
+listen = 9000
+pm = dynamic
+pm.max_children = 120
+pm.start_servers = 50
+pm.min_spare_servers = 1
+pm.max_spare_servers = 120
+pm.max_requests = 1500
+pm.status_path = /status
+
+ping.path = /ping
+ping.response = pong

--- a/setup_native_nfs_docker_osx.sh
+++ b/setup_native_nfs_docker_osx.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+#
+# Coppied from https://github.com/ajeetraina/docker101/tree/master/os/macOS/nfs
+#
+
+OS=`uname -s`
+MAC_VERSION=`sw_vers -productVersion | awk -F. '{ printf "%s.%s", $1, $2; }'`;
+CATALINA_VERSION="10.15";
+
+if [ $OS != "Darwin" ]; then
+  echo "This script is OSX-only. Please do not run it on any other Unix."
+  exit 1
+fi
+
+if [[ $EUID -eq 0 ]]; then
+  echo "This script must NOT be run with sudo/root. Please re-run without sudo." 1>&2
+  exit 1
+fi
+
+echo ""
+echo " +-----------------------------+"
+echo " | Setup native NFS for Docker |"
+echo " +-----------------------------+"
+echo ""
+
+echo "WARNING: This script will shut down running containers, delete volumes, delete current native NFS configs on this Mac"
+echo ""
+echo -n "Do you wish to proceed? [y]: "
+read decision
+
+if [ "$decision" != "y" ]; then
+  echo "Exiting. No changes made."
+  exit 1
+fi
+
+echo ""
+
+if ! docker ps > /dev/null 2>&1 ; then
+  echo "== Waiting for docker to start..."
+fi
+
+open -a Docker
+
+while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+echo "== Stopping running docker containers..."
+docker-compose down > /dev/null 2>&1
+
+osascript -e 'quit app "Docker"'
+
+echo "== Resetting folder permissions..."
+U=`id -u`
+G=`id -g`
+sudo chown -R "$U":"$G" .
+
+echo "== Setting up nfs..."
+
+# From catalina the directory has changed.
+if (( $(echo "$MAC_VERSION < $CATALINA_VERSION" |bc -l) )); then
+  LINE="/Users -alldirs -mapall=$U:$G localhost"
+else
+  LINE="/System/Volumes/Data -alldirs -mapall=$U:$G localhost"
+fi
+
+FILE=/etc/exports
+grep -xqF -- "$LINE" "$FILE" || sudo echo "$LINE" | sudo tee -a $FILE > /dev/null
+
+NFS_LINE="nfs.server.mount.require_resv_port = 0"
+NFS_FILE=/etc/nfs.conf
+grep -qF -- "$NFS_LINE" "$NFS_FILE" || sudo echo "$NFS_LINE" | sudo tee -a $NFS_FILE > /dev/null
+
+echo "== Restarting nfsd..."
+sudo nfsd restart
+
+echo "== Restarting docker..."
+open -a Docker
+
+while ! docker ps > /dev/null 2>&1 ; do sleep 2; done
+
+echo ""
+echo "SUCCESS! Now go run your containers 🐳"

--- a/symfony.lock
+++ b/symfony.lock
@@ -991,6 +991,9 @@
     "symplify/smart-file-system": {
         "version": "v7.1.3"
     },
+    "symplify/symplify-kernel": {
+        "version": "8.3.48"
+    },
     "textalk/websocket": {
         "version": "1.3.1"
     },


### PR DESCRIPTION
The script setup_native_nfs_docker_osx.sh will activate the NFS enabling
to speed up the mounted storage.

Adding health check for php-fpm container, just running the command
`docker-compose ps` it will show if the container is healthiness.

The HEALTHCHECK instruction tells Docker how to test a container
to check that it is still working. This can detect cases such as a
web server stuck in an infinite loop and unable to handle new
connections, even though the server process is still running.

Separating some commands into RUN instructions allow the Docker to cache
the instruction result to reuse in another moment.
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#leverage-build-cache

Co-authored-by: Kévin Dunglas <dunglas@gmail.com>
Co-authored-by: arti0090 <arti0090@gmail.com>