### PR TITLE
Remove composer --no-sugest deprecated call

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ COPY docker/php/php-cli.ini /usr/local/etc/php/php-cli.ini
 # https://getcomposer.org/doc/03-cli.md#composer-allow-superuser
 ENV COMPOSER_ALLOW_SUPERUSER=1
 RUN set -eux; \
-	composer global require "hirak/prestissimo:^0.3" --prefer-dist --no-progress --no-suggest --classmap-authoritative; \
+	composer global require "hirak/prestissimo:^0.3" --prefer-dist --no-progress --classmap-authoritative; \
 	composer clear-cache
 ENV PATH="${PATH}:/root/.composer/vendor/bin"
 
@@ -79,7 +79,7 @@ ARG APP_ENV=prod
 # prevent the reinstallation of vendors at every changes in the source code
 COPY composer.json composer.lock symfony.lock ./
 RUN set -eux; \
-	composer install --prefer-dist --no-autoloader --no-scripts --no-progress --no-suggest; \
+	composer install --prefer-dist --no-autoloader --no-scripts --no-progress; \
 	composer clear-cache
 
 # copy only specifically what we need

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -12,7 +12,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media
 
 	if [ "$APP_ENV" != 'prod' ]; then
-		composer install --prefer-dist --no-progress --no-suggest --no-interaction
+		composer install --prefer-dist --no-progress --no-interaction
 		bin/console assets:install --no-interaction
 		bin/console sylius:theme:assets:install public --no-interaction
 	fi


### PR DESCRIPTION
Removed call do deprecated Composer 2 option which has no effect and will be removed in Composer 3 to prevent:

```
You are using the deprecated option "--no-suggest". It has no effect and will break in Composer 3.
```
It's popup when building project or starting container.

Reference: https://php.watch/articles/composer-2#no--no-suggest