### PR TITLE
Disable auth for LiipImagineBundle controllers

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -116,6 +116,10 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
 
+        image_resolver:
+            pattern: ^/media/cache/resolve
+            security: false
+
     access_control:
         - { path: "%sylius.security.admin_regex%/_partial", role: IS_AUTHENTICATED_ANONYMOUSLY, ips: [127.0.0.1, ::1] }
         - { path: "%sylius.security.admin_regex%/_partial", role: ROLE_NO_ACCESS }


### PR DESCRIPTION
Ref: https://twitter.com/mbabker/status/1405962888792231939?s=21 and https://github.com/liip/LiipImagineBundle/pull/1383

Most apps don't need authenticated user info when resolving images, so we can sanely disable the security authentication for these routes.