### PR TITLE
Update php, nodejs and nginx in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 # the different stages of this Dockerfile are meant to be built into separate images
 # https://docs.docker.com/compose/compose-file/#target
 
-ARG PHP_VERSION=7.3
-ARG NODE_VERSION=10
-ARG NGINX_VERSION=1.16
+ARG PHP_VERSION=7.4
+ARG NODE_VERSION=12
+ARG NGINX_VERSION=1.21
 
 FROM php:${PHP_VERSION}-fpm-alpine AS sylius_php
 
@@ -32,8 +32,8 @@ RUN set -eux; \
 		zlib-dev \
 	; \
 	\
-	docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include --with-webp-dir=/usr/include --with-freetype-dir=/usr/include/; \
-	docker-php-ext-configure zip --with-libzip; \
+	docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype; \
+	docker-php-ext-configure zip --with-zip; \
 	docker-php-ext-install -j$(nproc) \
 		exif \
 		gd \

--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ARG APP_ENV=prod
 # prevent the reinstallation of vendors at every changes in the source code
 COPY composer.json composer.lock symfony.lock ./
 RUN set -eux; \
-	composer install --prefer-dist --no-autoloader --no-scripts --no-progress --no-suggest; \
+	composer install --prefer-dist --no-autoloader --no-scripts --no-progress; \
 	composer clear-cache
 
 # copy only specifically what we need

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -12,7 +12,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media
 
 	if [ "$APP_ENV" != 'prod' ]; then
-		composer install --prefer-dist --no-progress --no-suggest --no-interaction
+		composer install --prefer-dist --no-progress --no-interaction
 		bin/console assets:install --no-interaction
 		bin/console sylius:theme:assets:install public --no-interaction
 	fi


### PR DESCRIPTION
Updating the default versions in the Dockerfile.

The composer dependencies listed by Sylius standard no longer support PHP 7.3 and the NodeJS + nginx versions are heavily outdated.

Upgrading NodeJS even further can be done, but requires a lot more work as the front end dependencies are also pretty outdated. So I'd suggest doing it in a separate PR or development cycle.

Please don't just tag this and leave it hanging, currently the Docker setup is unusable because of this.
Perhaps we should add a step to the github actions workflow to check and confirm that the container images can actually be built, or even better build them and use them in the workflow. What do you think about that?