### PR TITLE
Increase PHP memory_limit for cli

### DIFF
--- a/docker/php/php-cli.ini
+++ b/docker/php/php-cli.ini
@@ -11,6 +11,6 @@ opcache.memory_consumption = 256
 realpath_cache_size = 4096K
 realpath_cache_ttl = 600
 
-memory_limit = 2G
+memory_limit = 3G
 post_max_size = 6M
 upload_max_filesize = 5M


### PR DESCRIPTION
The last release has required me to increase memory_limit to 3G on branch master on my two computers.

This is the last problem I had with the new docker setup. Maybe rebasing and merging this PR would be cool before release, especially the healthcheck https://github.com/Sylius/Sylius-Standard/pull/391

ping @lchrusciel 