### PR TITLE
Remove deprecated whitespace from tag filter

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,11 +174,11 @@ jobs:
 
             -   
                 name: Run non-JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript && ~@todo && ~@cli"
+                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="~@javascript&&~@todo&&~@cli"
             
             -
                 name: Run JS Behat
-                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript && ~@todo && ~@cli" --rerun
+                run: vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --rerun || vendor/bin/behat --colors --strict --no-interaction -vvv -f progress --tags="@javascript&&~@todo&&~@cli" --rerun
 
             -
                 name: Upload Behat logs

--- a/behat.yml.dist
+++ b/behat.yml.dist
@@ -63,4 +63,4 @@ default:
 
     gherkin:
         filters:
-            tags: "~@todo && ~@cli" # CLI is excluded as it registers an error handler that mutes fatal errors
+            tags: "~@todo&&~@cli" # CLI is excluded as it registers an error handler that mutes fatal errors


### PR DESCRIPTION
This removes the deprecation warning about the whitespace when running Behat.