### PR TITLE
Update python package name in nodejs step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -117,7 +117,7 @@ RUN set -eux; \
 		gcc \
 		git \
 		make \
-		python \
+		python2 \
 	;
 
 # prevent the reinstallation of vendors at every changes in the source code


### PR DESCRIPTION
Recent alpine updates require python 2 to be installed as `python3` package, otherwise image build fails.