### PR TITLE
Fix container build missing composer.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ WORKDIR /srv/sylius
 ARG APP_ENV=prod
 
 # prevent the reinstallation of vendors at every changes in the source code
-COPY composer.json composer.lock symfony.lock ./
+COPY composer.json symfony.lock ./
 RUN set -eux; \
 	composer install --prefer-dist --no-autoloader --no-scripts --no-progress; \
 	composer clear-cache


### PR DESCRIPTION
Do not copy non existent composer.lock. The image build correctly without this file anyways.

Related issues: #596, #606, #614.