### PR TITLE
Require Symfony 5.3 for Sylius 1.10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["7.4", "8.0"]
-                symfony: ["^4.4", "^5.2"]
+                symfony: ["4.4.*", "5.3.*"]
                 node: ["10.x"]
                 mysql: ["5.7", "8.0"]
 
@@ -85,7 +85,9 @@ jobs:
             -
                 name: Restrict Symfony version
                 if: matrix.symfony != ''
-                run: composer config extra.symfony.require "${{ matrix.symfony }}"
+                run: |
+                    composer global require --no-progress --no-scripts --no-plugins "symfony/flex:1.13.4"
+                    composer config extra.symfony.require "${{ matrix.symfony }}"
 
             -
                 name: Get Composer cache directory

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
         "symfony/flex": "^1.11"
     },
     "conflict": {
-        "symfony/form": "4.4.11 || 4.4.12"
+        "symfony/form": "4.4.11 || 4.4.12",
+        "symfony/password-hasher": "^6.0"
     },
     "require-dev": {
         "behat/behat": "^3.7",
@@ -71,7 +72,8 @@
             "dev-master": "1.9-dev"
         },
         "symfony": {
-            "allow-contrib": false
+            "allow-contrib": false,
+            "require": "5.3.*"
         }
     },
     "autoload": {


### PR DESCRIPTION
As Symfony 5.4 will be [properly supported in Sylius 1.11](https://github.com/Sylius/Sylius/pull/13339), we need to require Symfony 5.3 for Sylius 1.10. If Symfony 5.4 is used, after creating a project there is an exception about problems with the security bundle (see more [here](https://github.com/Sylius/Sylius/issues/13342))

Fixes https://github.com/Sylius/Sylius-Standard/issues/630