### PR TITLE
Add missing polishsymfonycommunity/symfony-mocker-container dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,8 @@
         "symfony/browser-kit": "^4.4 || ^5.2",
         "symfony/debug-bundle": "^4.4 || ^5.2",
         "symfony/intl": "^4.4 || ^5.2",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.2"
+        "symfony/web-profiler-bundle": "^4.4 || ^5.2",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },
     "config": {
         "preferred-install": {

--- a/config/services_test.yaml
+++ b/config/services_test.yaml
@@ -1,2 +1,5 @@
 imports:
     - { resource: "../vendor/sylius/sylius/src/Sylius/Behat/Resources/config/services.xml" }
+    
+sylius_api:
+    enabled: true

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -70,7 +70,7 @@ final class Kernel extends BaseKernel
 
     protected function getContainerBaseClass(): string
     {
-        if ($this->isTestEnvironment()) {
+        if ($this->isTestEnvironment() && class_exists(MockerContainer::class)) {
             return MockerContainer::class;
         }
 


### PR DESCRIPTION
Sylius 1.10.6 release has broken running the app based on the Sylius-Standard in a test environment. It's caused by [moving `"polishsymfonycommunity/symfony-mocker-container"` to `require-dev`](https://github.com/Sylius/Sylius/commit/673bc6662c3934f3e5c1e8cfa0a3fc8710a437b1#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34). `polishsymfonycommunity/symfony-mocker-container` is no longer being downloaded so it throws error because in test env it is used in `src/Kernel.php`.