### PR TITLE
Update composer.json to alias 1.11 correctly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -69,7 +69,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.9-dev"
+            "dev-master": "1.11-dev"
         },
         "symfony": {
             "allow-contrib": false


### PR DESCRIPTION
Currently composer.json aliases dev-master as 1.9, though this should ofcourse be 1.11 at this point in time!