### PR TITLE
Require doctrine/dbal:^2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     ],
     "require": {
         "php": "^7.4 || ^8.0",
+        "doctrine/dbal": "^2.7",
         "sylius/paypal-plugin": "^1.2.1",
         "sylius/sylius": "^1.10",
         "symfony/dotenv": "^4.4 || ^5.2",


### PR DESCRIPTION
Same as https://github.com/Sylius/Sylius/pull/13252, without it, after running `composer create-project ...` and then applying migrations, there is a nasty exception:

<img width="1428" alt="Zrzut ekranu 2021-12-21 o 14 36 27" src="https://user-images.githubusercontent.com/6212718/146939384-3bd8ccc1-200b-4660-8e1a-7d40934e25a7.png">
