### PR TITLE
Upgrade required version of PHP to 8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "sylius/paypal-plugin": "^1.2.1",
         "sylius/sylius": "^1.11@dev",
         "symfony/dotenv": "^4.4 || ^5.2",
@@ -69,7 +69,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.10-dev"
+            "dev-master": "1.11-dev"
         },
         "symfony": {
             "allow-contrib": false


### PR DESCRIPTION
~~This updates composer.json to match the requirements in Sylius/Sylius master: PHP `^8.0` and Symfony `^5.4`.~~

~~Also adds a the `extra/symfony/require` element with the value of `^5.4`. This will mean that whenever `composer require symfony/whatev` is issued, it will automatically require `^5.4` when possible, so you won't end up with a mix of packages from 5.4 and 6.x.~~

~~Also bumps `symfony/flex` requirement to `^2.0` (fixes #645).~~

This updates composer.json to require PHP ^8.0.

Also changes `dev-master` branch alias to `1.11-dev` (fixes #635). Although maybe that should already be changed to `1.12-dev` instead?
