### PR TITLE
Migrate security config to the new SF5.3 authenticator-based system

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -11,7 +11,7 @@ parameters:
     sylius.security.new_api_user_account_regex: "^%sylius.security.new_api_user_account_route%"
 
 security:
-    always_authenticate_before_granting: true
+    enable_authenticator_manager: true
     providers:
         sylius_admin_user_provider:
             id: sylius.admin_user_provider.email_or_name_based
@@ -22,7 +22,7 @@ security:
         sylius_api_shop_user_provider:
             id: sylius.shop_user_provider.email_or_name_based
 
-    encoders:
+    password_hashers:
         Sylius\Component\User\Model\UserInterface: argon2i
     firewalls:
         admin:
@@ -38,7 +38,7 @@ security:
                 default_target_path: sylius_admin_dashboard
                 use_forward: false
                 use_referer: true
-                csrf_token_generator: security.csrf.token_manager
+                enable_csrf: true
                 csrf_parameter: _csrf_admin_security_token
                 csrf_token_id: admin_authenticate
             remember_me:
@@ -50,37 +50,30 @@ security:
             logout:
                 path: sylius_admin_logout
                 target: sylius_admin_login
-            anonymous: true
 
         new_api_admin_user:
             pattern: "%sylius.security.new_api_admin_regex%/.*"
             provider: sylius_api_admin_user_provider
             stateless: true
-            anonymous: true
             json_login:
                 check_path: "%sylius.security.new_api_admin_route%/authentication-token"
                 username_path: email
                 password_path: password
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            jwt: ~
 
         new_api_shop_user:
             pattern: "%sylius.security.new_api_shop_regex%/.*"
             provider: sylius_api_shop_user_provider
             stateless: true
-            anonymous: true
             json_login:
                 check_path: "%sylius.security.new_api_shop_route%/authentication-token"
                 username_path: email
                 password_path: password
                 success_handler: lexik_jwt_authentication.handler.authentication_success
                 failure_handler: lexik_jwt_authentication.handler.authentication_failure
-            guard:
-                authenticators:
-                    - lexik_jwt_authentication.jwt_token_authenticator
+            jwt: ~
 
         shop:
             switch_user: { role: ROLE_ALLOWED_TO_SWITCH }
@@ -97,7 +90,7 @@ security:
                 default_target_path: sylius_shop_homepage
                 use_forward: false
                 use_referer: true
-                csrf_token_generator: security.csrf.token_manager
+                enable_csrf: true
                 csrf_parameter: _csrf_shop_security_token
                 csrf_token_id: shop_authenticate
             remember_me:
@@ -110,7 +103,6 @@ security:
                 target: sylius_shop_login
                 invalidate_session: false
                 success_handler: sylius.handler.shop_user_logout
-            anonymous: true
 
         dev:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
@@ -121,22 +113,22 @@ security:
             security: false
 
     access_control:
-        - { path: "%sylius.security.admin_regex%/_partial", role: IS_AUTHENTICATED_ANONYMOUSLY, ips: [127.0.0.1, ::1] }
+        - { path: "%sylius.security.admin_regex%/_partial", role: PUBLIC_ACCESS, ips: [127.0.0.1, ::1] }
         - { path: "%sylius.security.admin_regex%/_partial", role: ROLE_NO_ACCESS }
-        - { path: "%sylius.security.shop_regex%/_partial", role: IS_AUTHENTICATED_ANONYMOUSLY, ips: [127.0.0.1, ::1] }
+        - { path: "%sylius.security.shop_regex%/_partial", role: PUBLIC_ACCESS, ips: [127.0.0.1, ::1] }
         - { path: "%sylius.security.shop_regex%/_partial", role: ROLE_NO_ACCESS }
 
-        - { path: "%sylius.security.admin_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: "%sylius.security.shop_regex%/login", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.admin_regex%/login", role: PUBLIC_ACCESS }
+        - { path: "%sylius.security.shop_regex%/login", role: PUBLIC_ACCESS }
 
-        - { path: "%sylius.security.shop_regex%/register", role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: "%sylius.security.shop_regex%/verify", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.shop_regex%/register", role: PUBLIC_ACCESS }
+        - { path: "%sylius.security.shop_regex%/verify", role: PUBLIC_ACCESS }
 
         - { path: "%sylius.security.admin_regex%", role: ROLE_ADMINISTRATION_ACCESS }
         - { path: "%sylius.security.shop_regex%/account", role: ROLE_USER }
 
         - { path: "%sylius.security.new_api_admin_regex%/.*", role: ROLE_API_ACCESS }
-        - { path: "%sylius.security.new_api_admin_route%/authentication-token", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.new_api_admin_route%/authentication-token", role: PUBLIC_ACCESS }
         - { path: "%sylius.security.new_api_user_account_regex%/.*", role: ROLE_USER }
-        - { path: "%sylius.security.new_api_shop_route%/authentication-token", role: IS_AUTHENTICATED_ANONYMOUSLY }
-        - { path: "%sylius.security.new_api_shop_regex%/.*", role: IS_AUTHENTICATED_ANONYMOUSLY }
+        - { path: "%sylius.security.new_api_shop_route%/authentication-token", role: PUBLIC_ACCESS }
+        - { path: "%sylius.security.new_api_shop_regex%/.*", role: PUBLIC_ACCESS }


### PR DESCRIPTION
This patch migrates security config to the new authenticator-based system introduced in Symfony 5.1.
Guard-based authentication has been deprecated in Symfony 5.3. Luckily, not much needs to change for us since Sylius didn't have any custom Guard authenticators to begin with.

The patch also drops `always_authenticate_before_granting: true` from config. This option [has been deprecated](https://symfony.com/doc/5.4/reference/configuration/security.html#always-authenticate-before-granting) since Symfony 5.4, and it's unclear why or whether it was needed in the first place, and it caused me personally some headache (see symfony/symfony#43375).

Requires #659 for the sake of consistency.