### PR TITLE
Drop symfony4 support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.0"]
-                symfony: ["^4.4", "^5.4"]
+                symfony: ["^5.4"]
                 node: ["14.x"]
                 mysql: ["5.7", "8.0"]
 

--- a/composer.json
+++ b/composer.json
@@ -27,11 +27,8 @@
         "php": "^8.0",
         "sylius/paypal-plugin": "^1.2.1",
         "sylius/sylius": "^1.11@dev",
-        "symfony/dotenv": "^4.4 || ^5.2",
-        "symfony/flex": "^1.11"
-    },
-    "conflict": {
-        "symfony/form": "4.4.11 || 4.4.12"
+        "symfony/dotenv": "^5.4",
+        "symfony/flex": "^2.1"
     },
     "require-dev": {
         "behat/behat": "^3.7",
@@ -55,10 +52,10 @@
         "phpunit/phpunit": "^8.5",
         "stripe/stripe-php": "^6.43",
         "sylius-labs/coding-standard": "^4.0",
-        "symfony/browser-kit": "^4.4 || ^5.2",
-        "symfony/debug-bundle": "^4.4 || ^5.2",
-        "symfony/intl": "^4.4 || ^5.2",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.2",
+        "symfony/browser-kit": "^5.4",
+        "symfony/debug-bundle": "^5.4",
+        "symfony/intl": "^5.4",
+        "symfony/web-profiler-bundle": "^5.4",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0"
     },
     "config": {
@@ -69,10 +66,11 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.11-dev"
+            "dev-master": "1.12-dev"
         },
         "symfony": {
-            "allow-contrib": false
+            "allow-contrib": false,
+            "require": "^5.4"
         }
     },
     "autoload": {


### PR DESCRIPTION
This is a spin-off from #659 and includes #659.

It updates composer.json:

1. All Symfony packages which currently require v4.4 or v5.x will now require `^5.4`.
2. The `extra/symfony/require` element is added with the value of `^5.4`. This will mean that whenever `composer require symfony/*` is issued, it will automatically require `^5.4` when possible, so you won't end up with a mix of packages from 5.4 and 6.x.
3. `symfony/flex` requirement bumped to `^2.1` (contains #661 and deprecates #645).