### PR TITLE
[Docker] Bring back python2 dep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,7 @@ RUN set -eux; \
 		gcc \
 		git \
 		make \
+		python2 \
 	;
 
 # prevent the reinstallation of vendors at every changes in the source code


### PR DESCRIPTION
Revert of #643. It is still needed due to node and gyp dependency 