### PR TITLE
Enable Sylius API in dev by default

### DIFF
--- a/config/packages/dev/_sylius.yaml
+++ b/config/packages/dev/_sylius.yaml
@@ -1,0 +1,2 @@
+sylius_api:
+    enabled: true


### PR DESCRIPTION
For easier development of testing of the new application 🖖 It was already done for Sylius/Sylius [a long time ago](https://github.com/Sylius/Sylius/pull/12804).