### PR TITLE
[README] Add reasonable defaults configs for mailing and messenger to avoid production errors

### DIFF
--- a/.env
+++ b/.env
@@ -19,13 +19,13 @@ DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%
 # For Gmail as a transport, use: "gmail://username:password@localhost"
 # For a generic SMTP server, use: "smtp://localhost:25?encryption=&auth_mode="
 # Delivery is disabled by default via "null://localhost"
-MAILER_URL=smtp://localhost
+MAILER_URL=null://localhost
 ###< symfony/swiftmailer-bundle ###
 
 ###> symfony/messenger ###
 # Choose one of the transports below
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
-# MESSENGER_TRANSPORT_DSN=doctrine://default
+MESSENGER_TRANSPORT_DSN=doctrine://default
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 ###< symfony/messenger ###
 


### PR DESCRIPTION
The current mailing config results in 500 errors - this is the result that we can be sure of. So, it is better to turn it off by default, in my humble opinion. People who need mailing will adjust it anyway. The rest won't have a broken website. 

The second config is quite similar. This is our recommendation, so it is reasonable to have it there.