### PR TITLE
[Docker]Force no-interaction mode on installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ARG APP_ENV=prod
 # prevent the reinstallation of vendors at every changes in the source code
 COPY composer.* symfony.lock ./
 RUN set -eux; \
-    composer install --prefer-dist --no-autoloader --no-scripts --no-progress; \
+    composer install --prefer-dist --no-autoloader --no-interaction --no-scripts --no-progress; \
     composer clear-cache
 
 # copy only specifically what we need
@@ -95,8 +95,8 @@ RUN set -eux; \
     composer dump-autoload --classmap-authoritative; \
     APP_SECRET='' composer run-script post-install-cmd; \
     chmod +x bin/console; sync; \
-    bin/console sylius:install:assets; \
-    bin/console sylius:theme:assets:install public
+    bin/console sylius:install:assets --no-interaction; \
+    bin/console sylius:theme:assets:install public --no-interaction
 
 VOLUME /srv/sylius/var
 


### PR DESCRIPTION
During an installation the composer asks for plugins (https://getcomposer.org/doc/06-config.md#allow-plugins) that leads to failing Docker build and making the terminal interactive.

How to reproduce the problem? Create a project from current Sylius-Standard and try to run `docker compose up -d`