### PR TITLE
[Docker]Define MySQL platform as linux/amd64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,7 @@ services:
 
   mysql:
     image: percona:5.7
+    platform: linux/amd64
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-nopassword}
       - MYSQL_DATABASE=sylius


### PR DESCRIPTION
MySQL supports only amd64 architecture therefore without defining a platform the docker-compose fails on image download.

<img width="1277" alt="Screenshot 2022-04-14 at 12 54 18" src="https://user-images.githubusercontent.com/17534504/163377821-dc282d17-5634-4565-b6e0-df17ab875a17.png">
