### PR TITLE
[docker]Remove Docker Compose optional version

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   php:
     image: quay.io/sylius/php:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 services:
   php:
     build:


### PR DESCRIPTION
<img width="949" alt="Screenshot 2022-05-04 at 09 22 12" src="https://user-images.githubusercontent.com/17534504/166638147-12195cf8-0ebc-43fd-a60f-ec05f4aae49e.png">

The Docker Compose `version` is optional and there is no value to keeping that as the latest specification is just a "Compose Specification" instead of value-versioning https://docs.docker.com/compose/compose-file/

More to read in Docker Compose versioning reference: https://docs.docker.com/compose/compose-file/compose-versioning/

Current Docker Compose version: v2.4.1