### PR TITLE
[docker]Execute yarn build in production Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -142,7 +142,7 @@ COPY docker/node/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 
 ENTRYPOINT ["docker-entrypoint"]
-CMD ["yarn", "watch"]
+CMD ["yarn", "build"]
 
 FROM nginx:${NGINX_VERSION}-alpine AS sylius_nginx
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       #   - quay.io/sylius/nodejs:latest
       #   - quay.io/sylius/nginx:latest
     image: node:latest
+    command: ["yarn", "watch"]
     depends_on:
       - php
     environment:


### PR DESCRIPTION
The Dockerfile is "production oriented", yet it specifies the default command as `yarn watch` which executes a process of actively looking for changes. We don't need to do that in the production environment as the purpose of the node container would be to build and store assets and media files.

To maintain development environment the `yarn watch` command was specified in the `docker-compose`