### PR TITLE
[docker]Do not download images as they don't exist

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,6 @@ services:
     build:
       context: .
       target: sylius_php
-        # Quay does not work, should be replaced in future with f.e. ghcr.io
-        # cache_from:
-        #   - quay.io/sylius/php:latest
-        #   - quay.io/sylius/nodejs:latest
-        #   - quay.io/sylius/nginx:latest
-    image: php:latest
     depends_on:
       - mysql
     environment:
@@ -48,12 +42,6 @@ services:
     build:
       context: .
       target: sylius_node
-      # Quay does not work, should be replaced in future with f.e. ghcr.io
-      # cache_from:
-      #   - quay.io/sylius/php:latest
-      #   - quay.io/sylius/nodejs:latest
-      #   - quay.io/sylius/nginx:latest
-    image: node:latest
     depends_on:
       - php
     environment:
@@ -70,12 +58,6 @@ services:
     build:
       context: .
       target: sylius_nginx
-    image: nginx:latest
-      # Quay does not work, should be replaced in future with f.e. ghcr.io
-      # cache_from:
-      #   - quay.io/sylius/php:latest
-      #   - quay.io/sylius/nodejs:latest
-      #   - quay.io/sylius/nginx:latest
     depends_on:
       - php
       - node # to ensure correct build order


### PR DESCRIPTION
The images some time ago (2018) were pointing to the `quay.io/sylius/XYZ:latest` images, now they are pointing to the official images that do not make sense in this type of building docker compose.