### PR TITLE
[docker]Use mysql instead of percona

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,7 +20,7 @@ services:
 
   mysql:
     # in production, we may want to use a managed database service
-    image: percona:5.7
+    image: mysql:5.7 # Sylius is fully working on mysql 8.0 version
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:?MYSQL_ROOT_PASSWORD is not set or empty}
       - MYSQL_DATABASE=sylius_prod

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - public-media:/srv/sylius/public/media:rw
 
   mysql:
-    image: percona:5.7
+    image: mysql:5.7 # Sylius is fully working on mysql 8.0 version
     platform: linux/amd64
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-nopassword}


### PR DESCRIPTION
The Percona was introduced in the docker-compose in 2018, but we officially do not support this database provider (even if it is MySQL-based db engine)