### PR TITLE
[docker]Change quay.io/sylius images to building image from scratch

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -2,7 +2,9 @@ version: '3.4'
 
 services:
   php:
-    image: quay.io/sylius/php:latest
+    build:
+      context: .
+      target: sylius_php
     depends_on:
       - mysql
     environment:
@@ -32,7 +34,9 @@ services:
 
   nginx:
     # in production, we may want to use a static website hosting service
-    image: quay.io/sylius/nginx:latest
+    build:
+      context: .
+      target: sylius_nginx
     depends_on:
       - php
     volumes:


### PR DESCRIPTION
The `quay.io/sylius/php:latest` and `quay.io/sylius/nginx:latest` do not exist anymore, but we can still build it from local Dockerfile just like in the dev environment.