### PR TITLE
[Maintenance] Update Sylius to newest dev master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
                 name: Prepare test application assets
                 run: |
                     bin/console assets:install public -vvv
-                    yarn build
+                    GULP_ENV=prod yarn build
 
             -
                 name: Prepare test application cache

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
     "require": {
         "php": "^8.0",
         "sylius/paypal-plugin": "^1.2.1",
-        "sylius/sylius": "^1.11",
+        "sylius/sylius": "^1.12@dev",
         "symfony/dotenv": "^5.4",
         "symfony/flex": "^2.1"
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "dependencies": {
     "babel-polyfill": "^6.26.0",
-    "chart.js": "^2.9.3",
+    "chart.js": "^3.7.1",
     "jquery": "^3.5.0",
     "jquery.dirtyforms": "^2.0.0",
     "lightbox2": "^2.9.0",
@@ -33,12 +33,12 @@
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglifycss": "^1.0.5",
     "merge-stream": "^1.0.0",
-    "rollup": "^0.60.2",
+    "rollup": "^0.66.2",
     "rollup-plugin-babel": "^3.0.4",
     "rollup-plugin-commonjs": "^9.1.3",
     "rollup-plugin-inject": "^2.0.0",
     "rollup-plugin-node-resolve": "^3.3.0",
-    "rollup-plugin-uglify": "^4.0.0",
+    "rollup-plugin-uglify": "^6.0.2",
     "sass": "^1.48.0",
     "sass-loader": "^7.0.1",
     "upath": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-if": "^2.0.0",
     "gulp-livereload": "^4.0.1",
     "gulp-order": "^1.1.1",
-    "gulp-sass": "^4.0.1",
+    "gulp-sass": "^5.1.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-uglifycss": "^1.0.5",
     "merge-stream": "^1.0.0",
@@ -39,6 +39,7 @@
     "rollup-plugin-inject": "^2.0.0",
     "rollup-plugin-node-resolve": "^3.3.0",
     "rollup-plugin-uglify": "^4.0.0",
+    "sass": "^1.48.0",
     "sass-loader": "^7.0.1",
     "upath": "^1.1.0",
     "yargs": "^6.4.0"


### PR DESCRIPTION
From time to time, the last released version is not enough on master here. Some changes we would like to prepare in advance like #690. 

^1.12@dev makes the most sense to me - it is clear, that we are working on the development of v1.12, but accepting dev-master. 

Ref. https://semver.madewithlove.com/?package=sylius%2Fsylius&constraint=^1.11&stability=dev (but for version 1.11 to see how it behaves)