### PR TITLE
[maintenance]Create autolabeler config for Sylius-Standard

### DIFF
--- a/.github/autolabeler.yml
+++ b/.github/autolabeler.yml
@@ -1,0 +1,2 @@
+Maintenance: ['etc/', '.github/', '*.md']
+Docker: ['docker/', '.docker/', 'Dockerfile', 'docker-compose.*']


### PR DESCRIPTION
Same as in Sylius/Sylius auto labeling is nice automation. At this moment I don't know what kind of bot we use for auto labeling.

EDIT. I enabled https://github.com/apps/probot-autolabeler for Sylius-Standard