### PR TITLE
[maintenance]Enable Node 16 test pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
             matrix:
                 php: ["8.0"]
                 symfony: ["^5.4"]
-                node: ["14.x"]
+                node: ["14.x", "16.x"]
                 mysql: ["5.7", "8.0"]
 
         env:
@@ -47,7 +47,7 @@ jobs:
 
             -
                 name: Setup Node
-                uses: actions/setup-node@v1
+                uses: actions/setup-node@v2
                 with:
                     node-version: "${{ matrix.node }}"
 


### PR DESCRIPTION
## Introduction

We test and maintain Node 16 and 14 on Sylius/Sylius repository. Therefore it would be nice to have it tested in the project template too.

## Done

Add node 16 version to the pipeline matrix and update the setup-node action to the latest version.