### PR TITLE
[maintenance]Specify config param to auto-merge pipeline

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -15,3 +15,4 @@ jobs:
                 with:
                     target: minor
                     github-token: ${{ secrets.DEPENDABOT_TOKEN }}
+                    config: .github/dependabot.yml


### PR DESCRIPTION
## Introduction

I asked myself why the https://github.com/Sylius/Sylius-Standard/pull/734 PR is failing and that's probably because of an invalid config specified for the Dependabot.

<img width="664" alt="Screenshot 2022-05-17 at 15 47 00" src="https://user-images.githubusercontent.com/17534504/168826324-419cc9a0-62fd-468c-9c57-9f527a00c1ca.png">

Watch the Input section. Default config differs from `.github/dependabot.yml` https://github.com/ahmadnassri/action-dependabot-auto-merge#inputs 