### PR TITLE
[docker]Use mlocati/php-extension-installer to simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,51 +14,12 @@ RUN apk add --no-cache \
         gettext \
         git \
         mariadb-client \
+        unzip \
     ;
 
-ARG APCU_VERSION=5.1.21
-RUN set -eux; \
-	apk add --no-cache --virtual .build-deps \
-		$PHPIZE_DEPS \
-		coreutils \
-		freetype-dev \
-		icu-dev \
-		libjpeg-turbo-dev \
-		libpng-dev \
-		libtool \
-		libwebp-dev \
-		libzip-dev \
-		mariadb-dev \
-		zlib-dev \
-	; \
-	\
-	docker-php-ext-configure gd --with-jpeg --with-webp --with-freetype; \
-	docker-php-ext-configure zip --with-zip; \
-	docker-php-ext-install -j$(nproc) \
-		exif \
-		gd \
-		intl \
-		pdo_mysql \
-		zip \
-	; \
-	pecl install \
-		apcu-${APCU_VERSION} \
-	; \
-	pecl clear-cache; \
-	docker-php-ext-enable \
-		apcu \
-		opcache \
-	; \
-	\
-	runDeps="$( \
-		scanelf --needed --nobanner --format '%n#p' --recursive /usr/local/lib/php/extensions \
-			| tr ',' '\n' \
-			| sort -u \
-			| awk 'system("[ -e /usr/local/lib/" $1 " ]") == 0 { next } { print "so:" $1 }' \
-	)"; \
-	apk add --no-cache --virtual .sylius-phpexts-rundeps $runDeps; \
-	\
-	apk del .build-deps
+COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+
+RUN install-php-extensions zip gd intl exif pdo_mysql opcache apcu xml curl mbstring
 
 COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
 COPY docker/php/php.ini /usr/local/etc/php/php.ini


### PR DESCRIPTION
The https://github.com/mlocati/docker-php-extension-installer is highly popular in the docker and PHP community because it does one very good thing - simplify the installation of PHP extensions and their dependencies.

Should we at Sylius care about what alpine package install to have PDO extensions enabled? In my opinion no.