### PR TITLE
[docker]Get back container names

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,5 +1,6 @@
 services:
   php:
+    container_name: php
     build:
       context: .
       target: sylius_php
@@ -19,6 +20,7 @@ services:
       - ./public/media:/srv/sylius/public/media:rw
 
   mysql:
+    container_name: mysql
     # in production, we may want to use a managed database service
     image: mysql:5.7 # Sylius is fully working on mysql 8.0 version
     environment:
@@ -31,6 +33,7 @@ services:
       - ./docker/mysql/data:/var/lib/mysql:rw,delegated
 
   nginx:
+    container_name: nginx
     # in production, we may want to use a static website hosting service
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   php:
+    container_name: php
     build:
       context: .
       target: sylius_php
@@ -22,6 +23,7 @@ services:
       - public-media:/srv/sylius/public/media:rw
 
   mysql:
+    container_name: mysql
     image: mysql:5.7 # Sylius is fully working on mysql 8.0 version
     platform: linux/amd64
     environment:
@@ -37,6 +39,7 @@ services:
       - "3306:3306"
 
   node:
+    container_name: node
     build:
       context: .
       target: sylius_node
@@ -54,6 +57,7 @@ services:
       - "35729:35729"
 
   nginx:
+    container_name: nginx
     build:
       context: .
       target: sylius_nginx


### PR DESCRIPTION
It's just simpler to run docker execute commands with names like node instead of `sylius-standard_node`