### PR TITLE
[maintenance]Use GITHUB_TOKEN secret instead of DEPENDABOT_TOKEN

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -7,12 +7,16 @@ jobs:
     auto-merge:
         runs-on: ubuntu-18.04
         steps:
-            -   uses: actions/checkout@v2
+            -
+                name: Checkout repository
+                uses: actions/checkout@v2
+                with:
+                    token: ${{ secrets.GITHUB_TOKEN }}
 
             -
                 name: Auto-merge minor dependencies upgrades
                 uses: ahmadnassri/action-dependabot-auto-merge@v2
                 with:
                     target: minor
-                    github-token: ${{ secrets.DEPENDABOT_TOKEN }}
+                    github-token: ${{ secrets.GITHUB_TOKEN }}
                     config: .github/dependabot.yml


### PR DESCRIPTION
https://github.com/ahmadnassri/action-dependabot-auto-merge/issues/58

Our and not only auto-merge does not work. Setting same token for checkout and dependabot may solve the issue

```
/action/node_modules/@actions/core/lib/core.js:94
        throw new Error(`Input required and not supplied: ${name}`);
              ^

Error: Input required and not supplied: github-token
    at Object.getInput (/action/node_modules/@actions/core/lib/core.js:94:15)
    at file:///action/index.js:28:15
    at ModuleJob.run (node:internal/modules/esm/module_job:185:25)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:281:24)
    at async loadESM (node:internal/process/esm_loader:88:5)
    at async handleMainPromise (node:internal/modules/run_main:65:[12](https://github.com/Sylius/Sylius-Standard/runs/6523177356?check_suite_focus=true#step:4:13))
```