### PR TITLE
Revert "[maintenance]Try dark and light Sylius logo variants"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <p align="center">
     <a href="https://sylius.com" target="_blank">
-        <img src="https://demo.sylius.com/assets/shop/img/logo-dark.png#gh-dark-mode-only" alt="Sylius Logo"/>
-        <img src="https://demo.sylius.com/assets/shop/img/logo-light.png#gh-light-mode-only" alt="Sylius Logo"/>
+        <img src="https://demo.sylius.com/assets/shop/img/logo.png" />
     </a>
 </p>
 


### PR DESCRIPTION
Reverts Sylius/Sylius-Standard#742

It works only for images hosted on github.

https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#specifying-the-theme-an-image-is-shown-to