### PR TITLE
[maintenance]Make Sylius readme logo dark/light mode aware

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,5 @@
-<p align="center">
-    <a href="https://sylius.com" target="_blank">
-        <img src="https://demo.sylius.com/assets/shop/img/logo-dark.png#gh-dark-mode-only" alt="Sylius Logo"/>
-        <img src="https://demo.sylius.com/assets/shop/img/logo-light.png#gh-light-mode-only" alt="Sylius Logo"/>
-    </a>
-</p>
+![Sylius Logo](https://raw.githubusercontent.com/Sylius/Sylius/master/src/Sylius/Bundle/UiBundle/Resources/private/img/logo-light.png#gh-light-mode-only)
+![Sylius Logo](https://raw.githubusercontent.com/Sylius/Sylius/master/src/Sylius/Bundle/UiBundle/Resources/private/img/logo-dark.png#gh-dark-mode-only)
 
 <h1 align="center">Sylius Standard Edition</h1>
 


### PR DESCRIPTION
I had to use github served logos ;(