### PR TITLE
Pipeline that will test Sylius Store on Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,9 +6,11 @@
 **/.DS_Store
 **/.git/
 **/.gitattributes
+**/.github
 **/.gitignore
 **/.gitkeep
 **/.gitmodules
+**/.idea
 **/Dockerfile
 **/Thumbs.db
 .editorconfig

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -7,23 +7,48 @@ on:
 
 jobs:
     build-image:
+        name: Build Docker Image and Test Docker Compose
+        env:
+            MYSQL_PASSWORD: sylius-mysql
+            DOCKER_BUILDKIT: 1 # Requires Latest Buildx in docker CLI
+            COMPOSE_DOCKER_CLI_BUILD: 1 # Requires Latest Buildx in docker compose CLI
         strategy:
+            fail-fast: false
             matrix:
                 platform: [linux/amd64,linux/arm64]
+                docker_compose: [docker-compose.yml,docker-compose.prod.yml]
         
         runs-on: ubuntu-latest
         steps:
             -
                 name: Set Up QEMU
-                uses: docker/setup-qemu-action@v1
+                uses: docker/setup-qemu-action@v2
             -
                 name: Set Up Docker Buildx
-                uses: docker/setup-buildx-action@v1
+                uses: docker/setup-buildx-action@v2
             -
                 name: Build Image
-                uses: docker/build-push-action@v2
+                uses: docker/build-push-action@v3
                 with:
                     push: false
                     platforms: ${{ matrix.platform }}
                     cache-from: type=gha
                     cache-to: type=gha
+                    load: true
+            -
+                name: Shutdown Default MySQL
+                run: sudo service mysql stop
+                if: matrix.platform == 'linux/amd64'
+            -
+                name: Checkout Code
+                uses: actions/checkout@v3
+                if: matrix.platform == 'linux/amd64'
+            -
+                name: Setup Sylius Store
+                run: docker compose -f ${{ matrix.docker_compose }} up -d
+                if: matrix.platform == 'linux/amd64'
+            -
+                name: Health Check Store
+                run: ./docker/test.sh
+                if: matrix.platform == 'linux/amd64'
+                    

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - APP_ENV=dev
       - APP_DEBUG=1
       - APP_SECRET=EDITME
-      - DATABASE_URL=mysql://sylius:nopassword@mysql/sylius
+      - DATABASE_URL=mysql://sylius:${MYSQL_PASSWORD:-nopassword}@mysql/sylius
       - MAILER_URL=smtp://mailhog:1025
       - PHP_DATE_TIMEZONE=${PHP_DATE_TIMEZONE:-UTC}
     volumes:

--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -23,6 +23,7 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 	done
 
     bin/console doctrine:migrations:migrate --no-interaction
+    bin/console sylius:fixtures:load --no-interaction
 fi
 
 exec docker-php-entrypoint "$@"

--- a/docker/test.sh
+++ b/docker/test.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+readonly timeout=100
+readonly sleep_time=5
+
+i=1
+time=$((timeout * sleep_time))
+
+until curl -L --fail http://localhost:80 2>/dev/null
+do
+    i=$((i+1))
+
+    if [ "${i}" -gt "${timeout}" ]; then
+
+        echo "Sylius Store was never created, aborting due to ${time}s timeout!"
+        exit 1
+    else
+        echo "Sylius Store did not response"
+    fi
+
+    sleep $sleep_time
+done


### PR DESCRIPTION
The pipeline will build Sylius Store from `docker-compose.yml` and `docker-compose.prod.yml`, but only on the linux/amd64 platform as there is no functionality to override platform from the command nor does GitHub provide ARM runners.