### PR TITLE
[docker]Remove mariadb-client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,6 @@ RUN apk add --no-cache \
         acl \
         file \
         gettext \
-        mariadb-client \
         unzip \
     ;
 


### PR DESCRIPTION
As far as I see the usage of Dockerfile we don't need installed mariadb-client out of the box