### PR TITLE
Debug Node install for not found package python2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -79,7 +79,7 @@ RUN set -eux; \
 		gcc \
 		git \
 		make \
-		python2 \
+		python3 \
 	;
 
 # prevent the reinstallation of vendors at every changes in the source code


### PR DESCRIPTION
When I tried to install a similar project with docker-compose build, I encountered an error with apk and python2 inside the node part of the Dockerfile.

I fix this by changing python2 ref by python3. It worked for me.