### PR TITLE
[docker]Ensure var/sessions is created

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -7,7 +7,7 @@ if [ "${1#-}" != "$1" ]; then
 fi
 
 if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
-	mkdir -p var/cache var/log public/media
+	mkdir -p var/cache var/log var/sessions public/media
 	setfacl -R -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media
 	setfacl -dR -m u:www-data:rwX -m u:"$(whoami)":rwX var public/media
 


### PR DESCRIPTION
We store sessions in the `var/sessions` directory, but we do not create it if it does not exist. Therefore it tends to fail.


https://github.com/Sylius/Sylius-Standard/blob/master/docker-compose.prod.yml#L18