### PR TITLE
Configure recipes and Rector

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,17 +46,18 @@
         "lchrusciel/api-test-case": "^5.0",
         "phpspec/phpspec": "^7.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "1.5.4",
         "phpstan/phpstan-doctrine": "1.3.2",
         "phpstan/phpstan-webmozart-assert": "^1.1",
         "phpunit/phpunit": "^8.5",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+        "rector/rector": "^0.13.9",
+        "sylius/sylius-rector": "^0.1",
         "stripe/stripe-php": "^6.43",
         "sylius-labs/coding-standard": "^4.0",
         "symfony/browser-kit": "^5.4",
         "symfony/debug-bundle": "^5.4",
         "symfony/intl": "^5.4",
-        "symfony/web-profiler-bundle": "^5.4",
-        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
+        "symfony/web-profiler-bundle": "^5.4"
     },
     "config": {
         "preferred-install": {
@@ -76,7 +77,11 @@
         },
         "symfony": {
             "allow-contrib": false,
-            "require": "^5.4"
+            "require": "^5.4",
+            "endpoint": [
+                "https://raw.githubusercontent.com/Sylius/SyliusRecipes/flex/main/index.json",
+                "flex://defaults"
+            ]
         }
     },
     "autoload": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->import(__DIR__ . '/vendor/sylius/sylius-rector/config/config.php');
+    $rectorConfig->paths([
+        __DIR__ . '/src'
+    ]);
+};


### PR DESCRIPTION
Hi 🙋🏻‍♂️!
I've prepared a PR "activating" recipes and Rector. Before this PR can be merged we have to:

Rector:
- Replace the old Rector with the new one (both on GitHub and packagist.org)
- Release the `sylius/sylius-rector` package. This PR is made with the intention to mark the first version as `0.1`.

Recipes:
- Make the repository public