### PR TITLE
[docker]Create container that runs cronjobs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -128,3 +128,15 @@ ARG APP_ENV=dev
 RUN set -eux; \
     composer install --prefer-dist --no-autoloader --no-interaction --no-scripts --no-progress; \
     composer clear-cache
+
+FROM sylius_php_prod AS sylius_cron
+
+RUN set -eux; \
+	apk add --no-cache --virtual .build-deps \
+		apk-cron \
+	;
+
+COPY docker/cron/crontab /etc/crontabs/root
+
+ENTRYPOINT ["crond"]
+CMD ["-f"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -21,6 +21,22 @@ services:
     networks:
       - sylius
 
+  cron:
+    container_name: cron
+    build:
+      context: .
+      target: sylius_cron
+    depends_on:
+      - mysql
+    environment:
+      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD}@mysql/sylius_prod
+      PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
+      APP_ENV: prod
+      APP_DEBUG: 0
+      APP_SECRET: EDITME
+    networks:
+      - sylius
+
   mysql:
     container_name: mysql
     # in production, we may want to use a managed database service

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,0 +1,2 @@
+* * * * * bash php bin/console sylius:remove-expired-carts
+* * * * * bash php bin/console sylius:sylius:cancel-unpaid-orders

--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,2 +1,2 @@
-* * * * * bash php bin/console sylius:remove-expired-carts
-* * * * * bash php bin/console sylius:sylius:cancel-unpaid-orders
+* * * * * sh php bin/console sylius:remove-expired-carts
+* * * * * sh php bin/console sylius:sylius:cancel-unpaid-orders


### PR DESCRIPTION
With the docs: https://docs.sylius.com/en/latest/cookbook/deployment/cron-jobs.html comes requirements or a feature to run cronjobs for Sylius. The current docker does not provide this functionality out of the box, yet it would be nice. There it is.

The cronjobs are not helpful in the dev environments because containers tend to die rather quickly and commands are triggered manually. That's why the cronjobs container applies only to the production version of docker-compose.