### PR TITLE
[frontend]Run watch tasks in series instead of parallel

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -52,7 +52,7 @@ watchShop.description = 'Watch shop asset sources and rebuild on changes.';
 export const build = gulp.parallel(buildAdmin, buildShop);
 build.description = 'Build assets.';
 
-export const watch = gulp.parallel(watchAdmin, watchShop);
+export const watch = gulp.series(watchAdmin, watchShop);
 watch.description = 'Watch asset sources and rebuild on changes.';
 
 gulp.task('admin', buildAdmin);


### PR DESCRIPTION
I know there are probably not many people that use a gulp watch when working with Sylius Frontend. This PR will fix the development NODE container error:

```
[gulp-chug] (vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/gulpfile.babel.js) Error: listen EADDRINUSE: address already in use :::35729
    at Server.setupListenHandle [as _listen2] (net.js:1331:16)
    at listenInCluster (net.js:1379:12)
    at Server.listen (net.js:1465:7)
    at Server.listen (/srv/sylius/node_modules/tiny-lr/src/server.js:264:19)
    at Function.exports.listen (/srv/sylius/node_modules/gulp-livereload/index.js:97:18)
    at watchShop (/srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/gulpfile.babel.js:242:14)
    at bound (domain.js:421:15)
    at runBound (domain.js:432:12)
    at asyncRunner (/srv/sylius/node_modules/async-done/index.js:55:18)
    at processTicksAndRejections (internal/process/task_queues.js:77:11)
```

The error occurs because each of the watch tasks creates its own server.