### PR TITLE
[maintenance]Get rid of symfony polyfills

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
 
 COPY --from=php_extension_installer /usr/bin/install-php-extensions /usr/local/bin/
 
-RUN install-php-extensions zip gd intl exif pdo_mysql opcache apcu xml curl mbstring
+RUN install-php-extensions apcu curl exif gd iconv intl mbstring pdo_mysql opcache xml zip
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY docker/php/php.ini /usr/local/etc/php/php.ini

--- a/composer.json
+++ b/composer.json
@@ -108,5 +108,24 @@
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         }
+    },
+    "replace": {
+        "symfony/polyfill-apcu": "*",
+        "symfony/polyfill-ctype": "*",
+        "symfony/polyfill-iconv": "*",
+        "symfony/polyfill-intl": "*",
+        "symfony/polyfill-intl-grapheme": "*",
+        "symfony/polyfill-intl-icu": "*",
+        "symfony/polyfill-intl-idn": "*",
+        "symfony/polyfill-intl-normalizer": "*",
+        "symfony/polyfill-php54": "*",
+        "symfony/polyfill-php55": "*",
+        "symfony/polyfill-php56": "*",
+        "symfony/polyfill-php70": "*",
+        "symfony/polyfill-php71": "*",
+        "symfony/polyfill-php72": "*",
+        "symfony/polyfill-php73": "*",
+        "symfony/polyfill-php74": "*",
+        "symfony/polyfill-php80": "*"
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -676,38 +676,8 @@
     "symfony/password-hasher": {
         "version": "v5.3.2"
     },
-    "symfony/polyfill-ctype": {
-        "version": "v1.9.0"
-    },
-    "symfony/polyfill-iconv": {
-        "version": "v1.9.0"
-    },
-    "symfony/polyfill-intl-grapheme": {
-        "version": "v1.22.0"
-    },
-    "symfony/polyfill-intl-icu": {
-        "version": "v1.9.0"
-    },
-    "symfony/polyfill-intl-idn": {
-        "version": "v1.11.0"
-    },
-    "symfony/polyfill-intl-normalizer": {
-        "version": "v1.22.0"
-    },
     "symfony/polyfill-mbstring": {
         "version": "v1.9.0"
-    },
-    "symfony/polyfill-php56": {
-        "version": "v1.17.1"
-    },
-    "symfony/polyfill-php72": {
-        "version": "v1.9.0"
-    },
-    "symfony/polyfill-php73": {
-        "version": "v1.11.0"
-    },
-    "symfony/polyfill-php80": {
-        "version": "v1.22.0"
     },
     "symfony/polyfill-php81": {
         "version": "v1.23.0"


### PR DESCRIPTION
I personally think that's boomer that we have to do it. Still, by default Sylius will be installed with several polyfills, which are slower than PHP extensions and require a download, slowing down every aspect of developing and deploying applications.

The one I can't get rid `polyfill-mbstring` because of https://github.com/SyliusLabs/PolyfillSymfonySecurity/blob/master/composer.json#L20

<img width="397" alt="Screenshot 2022-08-29 at 22 11 19" src="https://user-images.githubusercontent.com/17534504/187289423-511ac0f1-f8b4-4e81-9aa8-fe7a0b9a2862.png">
