### PR TITLE
[docker] Load fixtures only on dev environment

### DIFF
--- a/docker/php/docker-entrypoint.sh
+++ b/docker/php/docker-entrypoint.sh
@@ -23,7 +23,10 @@ if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
 	done
 
     bin/console doctrine:migrations:migrate --no-interaction
-    bin/console sylius:fixtures:load --no-interaction
+
+    if [ "$APP_ENV" = 'dev' ]; then
+        bin/console sylius:fixtures:load --no-interaction
+    fi
 fi
 
 exec docker-php-entrypoint "$@"


### PR DESCRIPTION
https://github.com/Sylius/Sylius-Standard/issues/813

Turning off relading the fixtures is just one line, and I decided not to overcomplicate the default config and just keep the fixtures reloading on the dev environment, but not on production and testing.