### PR TITLE
fix: Composer install - FlySystemBundle not in kernel

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -59,4 +59,5 @@ return [
     SyliusLabs\DoctrineMigrationsExtraBundle\SyliusLabsDoctrineMigrationsExtraBundle::class => ['all' => true],
     Sylius\PayPalPlugin\SyliusPayPalPlugin::class => ['all' => true],
     SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
+    League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
League\FlysystemBundle\FlysystemBundle::class needs to be registered in the Kernel.php file