### PR TITLE
[docker]Keep the Gulp in the docker and prepare proper migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,6 @@ RUN set -eux; \
 
 # copy only specifically what we need
 COPY .env .env.prod .env.test .env.test_cached ./
-COPY assets assets/
 COPY bin bin/
 COPY config config/
 COPY public public/
@@ -84,6 +83,7 @@ RUN set -eux; \
 		g++ \
 		gcc \
 		make \
+        python2 \
 	;
 
 # prevent the reinstallation of vendors at every changes in the source code
@@ -95,17 +95,18 @@ RUN set -eux; \
 COPY --from=sylius_php_prod /srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/UiBundle/Resources/private       vendor/sylius/sylius/src/Sylius/Bundle/UiBundle/Resources/private/
 COPY --from=sylius_php_prod /srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/Resources/private    vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/Resources/private/
 COPY --from=sylius_php_prod /srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/Resources/private     vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/Resources/private/
-COPY --from=sylius_php_prod /srv/sylius/assets ./assets
+COPY --from=sylius_php_prod /srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/gulpfile.babel.js    vendor/sylius/sylius/src/Sylius/Bundle/AdminBundle/gulpfile.babel.js
+COPY --from=sylius_php_prod /srv/sylius/vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/gulpfile.babel.js     vendor/sylius/sylius/src/Sylius/Bundle/ShopBundle/gulpfile.babel.js
 
-COPY webpack.config.js ./
+COPY gulpfile.babel.js .babelrc ./
 RUN set -eux; \
-    yarn build:prod;
+    GULP_ENV=prod yarn gulp:build;
 
 COPY docker/node/docker-entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 
 ENTRYPOINT ["docker-entrypoint"]
-CMD ["yarn", "build"]
+CMD ["yarn", "gulp:build"]
 
 FROM nginx:${NGINX_VERSION}-alpine AS sylius_nginx
 

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - mysql
     environment:
-      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD}@mysql/sylius_prod
+      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD:?MYSQL_PASSWORD is not set or empty}@mysql/sylius_prod
       MAILER_URL: smtp://localhost
       PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
       APP_ENV: prod
@@ -26,7 +26,7 @@ services:
     # in production, we may want to use a managed database service
     image: mysql:5.7 # Sylius is fully working on mysql 8.0 version
     environment:
-      MYSQL_RANDOM_ROOT_PASSWORD: true
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
       MYSQL_DATABASE: sylius_prod
       MYSQL_USER: sylius
       MYSQL_PASSWORD: ${MYSQL_PASSWORD:?MYSQL_PASSWORD is not set or empty}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,12 +7,12 @@ services:
     depends_on:
       - mysql
     environment:
-      - APP_ENV=dev
-      - APP_DEBUG=1
-      - APP_SECRET=EDITME
-      - DATABASE_URL=mysql://sylius:${MYSQL_PASSWORD:-nopassword}@mysql/sylius
-      - MAILER_URL=smtp://mailhog:1025
-      - PHP_DATE_TIMEZONE=${PHP_DATE_TIMEZONE:-UTC}
+      APP_ENV: dev
+      APP_DEBUG: 1
+      APP_SECRET: EDITME
+      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD:-nopassword}@mysql/sylius
+      MAILER_URL: smtp://mailhog:1025
+      PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
     volumes:
       - .:/srv/sylius:rw,cached
       # if you develop on Linux, you may use a bind-mounted host directory instead
@@ -27,34 +27,34 @@ services:
     image: mysql:5.7 # Sylius is fully working on mysql 8.0 version
     platform: linux/amd64
     environment:
-      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-nopassword}
-      - MYSQL_DATABASE=sylius
-      - MYSQL_USER=sylius
-      - MYSQL_PASSWORD=${MYSQL_PASSWORD:-nopassword}
+      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD:-nopassword}
+      MYSQL_DATABASE: sylius
+      MYSQL_USER: sylius
+      MYSQL_PASSWORD: ${MYSQL_PASSWORD:-nopassword}
     volumes:
       - mysql-data:/var/lib/mysql:rw
       # you may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!
       # - ./docker/mysql/data:/var/lib/mysql:rw,delegated
     ports:
-      - "${MYSQL_PORT:-3306}:3306"
+      - ${MYSQL_PORT:-3306}:3306
 
   node:
     container_name: node
     build:
       context: .
       target: sylius_node
-    command: ["yarn", "watch"]
+    command: ["yarn", "gulp:watch"]
     depends_on:
       - php
     environment:
-      - GULP_ENV=dev
-      - PHP_HOST=php
-      - PHP_PORT=9000
+      GULP_ENV: dev
+      PHP_HOST: php
+      PHP_PORT: 9000
     volumes:
       - .:/srv/sylius:rw,cached
       - ./public:/srv/sylius/public:rw,delegated
     ports:
-      - "${NODE_PORT:-35729}:35729"
+      - ${NODE_PORT:-35729}:35729
 
   nginx:
     container_name: nginx
@@ -70,7 +70,7 @@ services:
       # - ./public/media:/srv/sylius/public/media:ro
       - public-media:/srv/sylius/public/media:ro,nocopy
     ports:
-      - "${HTTP_PORT:-80}:80"
+      - ${HTTP_PORT:-80}:80
 
   mailhog:
     # do not use in production!
@@ -80,7 +80,7 @@ services:
     # volumes:
     #   - ./docker/mailhog/maildir:/maildir:rw,delegated
     ports:
-      - "${MAILHOG_PORT:-8025}:8025"
+      - ${MAILHOG_PORT:-8025}:8025
 
 volumes:
   mysql-data:

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "watch": "encore dev --watch",
     "build": "encore dev",
     "build:prod": "encore production",
-    "gulp": "gulp build",
+    "gulp:build": "gulp build",
+    "gulp:watch": "gulp watch",
     "lint": "yarn lint:js",
     "lint:js": "eslint gulpfile.babel.js src/Sylius/Bundle/AdminBundle/gulpfile.babel.js src/Sylius/Bundle/ShopBundle/gulpfile.babel.js src/Sylius/Bundle/UiBundle/Resources/private/js src/Sylius/Bundle/AdminBundle/Resources/private/js src/Sylius/Bundle/ShopBundle/Resources/private/js",
     "postinstall": "semantic-ui-css-patch"


### PR DESCRIPTION
As we are going to support both GULP and WebPack in Sylius 1.12 we should do the same in Docker containers. I reverted some of the changes from https://github.com/Sylius/Sylius-Standard/pull/831 PR because the main branch docker is broken.

Let's make a step back and prepare the node container for webpack and for gulp.

FYI: https://github.com/Sylius/Sylius-Standard/issues/832