### PR TITLE
[docker]Improve the error message by simply rendering json response

### DIFF
--- a/docker/test.sh
+++ b/docker/test.sh
@@ -14,6 +14,7 @@ do
     if [ "${i}" -gt "${timeout}" ]; then
 
         echo "Sylius Store was never created, aborting due to ${time}s timeout!"
+        curl -L http://localhost:80 -H Accept:application/json
         exit 1
     else
         echo "Sylius Store did not response"


### PR DESCRIPTION
Instead of no error now we will get sth like this:

```
{"code":500,"message":"An exception has been thrown during the rendering of a template (\"Could not find the entrypoints file from Webpack: the file \"\/srv\/sylius\/public\/build\/shop\/entrypoints.json\" does not exist.\")."}%    
```