### PR TITLE
[docker]Integrate production config docker with Webpack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@ node_modules/
 var/*
 vendor/
 public/assets/
+public/build/
 public/bundles/
 public/css/
 public/js/

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ adminConfig.resolve.alias['sylius/bundle'] = syliusBundles;
 adminConfig.externals = Object.assign({}, adminConfig.externals, { window: 'window', document: 'document' });
 adminConfig.name = 'admin';
 
-Encore.reset()
+Encore.reset();
 
 // App shop config
 Encore


### PR DESCRIPTION
FYI https://github.com/Sylius/Sylius-Standard/issues/832

The PHP container now needs the frontend files. This is not the most distinguished solution, but it works. I will spend some more time polishing it. But now it is required to fix the 1.12 branch.

PS. it worked on the development image only because the command generated the files and syncs with local filesystem