### PR TITLE
[docker] Simple queue worker

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -7,12 +7,13 @@ services:
     depends_on:
       - mysql
     environment:
+      APP_DEBUG: 0
+      APP_ENV: prod
+      APP_SECRET: EDITME
       DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD}@mysql/sylius_prod
       MAILER_URL: smtp://localhost
+      MESSENGER_TRANSPORT_DSN: doctrine://default
       PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
-      APP_ENV: prod
-      APP_DEBUG: 0
-      APP_SECRET: EDITME
     volumes:
       # use a bind-mounted host directory, as we want to keep the sessions
       - ./var/sessions:/srv/sylius/var/sessions:rw
@@ -29,11 +30,30 @@ services:
     depends_on:
       - mysql
     environment:
-      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD}@mysql/sylius_prod
-      PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
       APP_ENV: prod
       APP_DEBUG: 0
       APP_SECRET: EDITME
+      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD}@mysql/sylius_prod
+      PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
+    networks:
+      - sylius
+    
+  worker:
+    container_name: worker
+    command: ["php", "bin/console", "messenger:consume", "main", "catalog_promotion_removal", "--limit=5", "--memory-limit=256M", "--time-limit=600"]
+    restart: always
+    build:
+      context: .
+      target: sylius_php_prod
+    depends_on:
+      - mysql
+    environment:
+      APP_ENV: prod
+      APP_DEBUG: 0
+      APP_SECRET: EDITME
+      DATABASE_URL: mysql://sylius:${MYSQL_PASSWORD}@mysql/sylius_prod
+      MESSENGER_TRANSPORT_DSN: doctrine://default
+      PHP_DATE_TIMEZONE: ${PHP_DATE_TIMEZONE:-UTC}
     networks:
       - sylius
 


### PR DESCRIPTION
The ideal scenario would be to have PHP CLI image that would run as a worker consumer, but It would increase the complexity. Let's start with a simple worker that would consume messages and always be up with the `restart: always` docker composer directive.