### PR TITLE
[docker] Update container's dependencies versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
                 uses: shivammathur/setup-php@v2
                 with:
                     php-version: "${{ matrix.php }}"
-                    extensions: intl
+                    extensions: intl, mbstring
                     tools: symfony
                     coverage: none
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # the different stages of this Dockerfile are meant to be built into separate images
 # https://docs.docker.com/compose/compose-file/#target
 
-ARG PHP_VERSION=8.0
+ARG PHP_VERSION=8.1
 ARG NODE_VERSION=16
 ARG NGINX_VERSION=1.21
 ARG ALPINE_VERSION=3.15
-ARG COMPOSER_VERSION=2
+ARG COMPOSER_VERSION=2.4
 ARG PHP_EXTENSION_INSTALLER_VERSION=latest
 
 FROM composer:${COMPOSER_VERSION} AS composer
@@ -24,7 +24,10 @@ RUN apk add --no-cache \
 
 COPY --from=php_extension_installer /usr/bin/install-php-extensions /usr/local/bin/
 
-RUN install-php-extensions apcu curl exif gd iconv intl mbstring pdo_mysql opcache xml zip
+# default PHP image extensions
+# ctype curl date dom fileinfo filter ftp hash iconv json libxml mbstring mysqlnd openssl pcre PDO pdo_sqlite Phar
+# posix readline Reflection session SimpleXML sodium SPL sqlite3 standard tokenizer xml xmlreader xmlwriter zlib
+RUN install-php-extensions apcu exif gd intl pdo_mysql opcache zip
 
 COPY --from=composer /usr/bin/composer /usr/bin/composer
 COPY docker/php/prod/php.ini        $PHP_INI_DIR/php.ini
@@ -51,7 +54,7 @@ RUN set -eux; \
     composer clear-cache
 
 # copy only specifically what we need
-COPY .env .env.prod .env.test .env.test_cached ./
+COPY .env .env.prod ./
 COPY assets assets/
 COPY bin bin/
 COPY config config/
@@ -128,6 +131,8 @@ COPY docker/php/dev/php.ini        $PHP_INI_DIR/php.ini
 COPY docker/php/dev/opcache.ini    $PHP_INI_DIR/conf.d/opcache.ini
 
 WORKDIR /srv/sylius
+
+COPY .env.test .env.test_cached ./
 
 ARG APP_ENV=dev
 

--- a/composer.json
+++ b/composer.json
@@ -135,7 +135,6 @@
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",
-        "symfony/polyfill-php80": "*",
-        "symfony/polyfill-php81": "*"
+        "symfony/polyfill-php80": "*"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -126,6 +126,7 @@
         "symfony/polyfill-intl-icu": "*",
         "symfony/polyfill-intl-idn": "*",
         "symfony/polyfill-intl-normalizer": "*",
+        "symfony/polyfill-mbstring": "*",
         "symfony/polyfill-php54": "*",
         "symfony/polyfill-php55": "*",
         "symfony/polyfill-php56": "*",
@@ -134,6 +135,7 @@
         "symfony/polyfill-php72": "*",
         "symfony/polyfill-php73": "*",
         "symfony/polyfill-php74": "*",
-        "symfony/polyfill-php80": "*"
+        "symfony/polyfill-php80": "*",
+        "symfony/polyfill-php81": "*"
     }
 }


### PR DESCRIPTION
Specify a minor version for the composer container. Update PHP to 8.1. Therefore we can get rid of php81 polyfill.

Also cleaned up files and extensions. Some of them are already installed. And we don't need .env.test in production container