### PR TITLE
[Maintenance] rector.php scaffold introduced

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->importNames();
+    $rectorConfig->import(__DIR__ . '/vendor/sylius/sylius-rector/config/config.php');
+    $rectorConfig->paths([
+        __DIR__ . '/src'
+    ]);
+};


### PR DESCRIPTION
Our [Sylius Rector Installation Guide](https://github.com/Sylius/SyliusRector) says there is a file for Sylius 1.12+ called rector.php, but it doesn't