### PR TITLE
[Composer] PHPStan upgraded

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,17 +46,18 @@
         "lchrusciel/api-test-case": "^5.0",
         "phpspec/phpspec": "^7.0",
         "phpstan/extension-installer": "^1.0",
-        "phpstan/phpstan": "1.5.4",
-        "phpstan/phpstan-doctrine": "1.3.2",
+        "phpstan/phpstan": "^1.8.4",
+        "phpstan/phpstan-doctrine": "^1.3.2",
         "phpstan/phpstan-webmozart-assert": "^1.1",
         "phpunit/phpunit": "^8.5",
+        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
+        "rector/rector": "^0.14.6",
         "stripe/stripe-php": "^6.43",
         "sylius-labs/coding-standard": "^4.0",
         "symfony/browser-kit": "^5.4",
         "symfony/debug-bundle": "^5.4",
         "symfony/intl": "^5.4",
-        "symfony/web-profiler-bundle": "^5.4",
-        "polishsymfonycommunity/symfony-mocker-container": "^1.0"
+        "symfony/web-profiler-bundle": "^5.4"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
Our [Sylius Rector installation guide](https://github.com/Sylius/SyliusRector) does not work as the `rector/rector` package requires `phpstan: ^1.8.7`
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/40125720/196703668-ab9c3e64-5604-4d43-a08a-9cc3cf45255f.png">
