### PR TITLE
[Composer] Remove composer.lock from .gitignore after creating the project

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -109,6 +109,7 @@
             "@auto-scripts"
         ],
         "post-create-project-cmd": [
+            "@php -r \"file_put_contents('.gitignore', str_replace('/composer.lock', '', file_get_contents('.gitignore')));\"",
             "@php bin/console sylius:inform-about-gus --ansi",
             "@php bin/console sylius:show-available-plugins --ansi"
         ],

--- a/composer.json
+++ b/composer.json
@@ -109,7 +109,7 @@
             "@auto-scripts"
         ],
         "post-create-project-cmd": [
-            "@php -r \"file_put_contents('.gitignore', str_replace('/composer.lock', '', file_get_contents('.gitignore')));\"",
+            "@php -r \"file_put_contents('.gitignore', str_replace('/composer.lock' . PHP_EOL, '', file_get_contents('.gitignore')));\"",
             "@php bin/console sylius:inform-about-gus --ansi",
             "@php bin/console sylius:show-available-plugins --ansi"
         ],


### PR DESCRIPTION
This fixes the issue #665.

Inspired by [sulu/skeleton](https://github.com/sulu/skeleton/blob/9f6f4d5792a737e96e20b5d9cce9523e43e064b7/composer.json#L118).

Can you review this, please? @lchrusciel 