### PR TITLE
[Composer] Sylius and SyliusResourceBundle versions adjusted

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     "require": {
         "php": "^8.0",
         "sylius/paypal-plugin": "^1.5.x-dev",
-        "sylius/sylius": "^1.12.x-dev",
+        "sylius/resource-bundle": "v1.10.0-BETA.1",
+        "sylius/sylius": "v1.12.0-rc.1",
         "symfony/dotenv": "^5.4 || ^6.0",
         "symfony/flex": "^2.1"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -542,9 +542,6 @@
     "sylius/theme-bundle": {
         "version": "v1.4.6"
     },
-    "symfony/amqp-messenger": {
-        "version": "v5.2.1"
-    },
     "symfony/asset": {
         "version": "v4.1.3"
     },
@@ -710,9 +707,6 @@
     "symfony/proxy-manager-bridge": {
         "version": "v4.1.3"
     },
-    "symfony/redis-messenger": {
-        "version": "v5.2.1"
-    },
     "symfony/routing": {
         "version": "4.0",
         "recipe": {
@@ -736,9 +730,6 @@
     },
     "symfony/security-csrf": {
         "version": "v5.2.1"
-    },
-    "symfony/security-guard": {
-        "version": "v4.4.18"
     },
     "symfony/security-http": {
         "version": "v4.4.18"


### PR DESCRIPTION
The order of installation of dependencies results in an outdated `SyliusResourceBundle` package which prevents adding products to the cart.
Requiring the latest `SyliusResourceBundle` adjusts the `phpstan/doc-parser` version:
<img width="863" alt="image" src="https://user-images.githubusercontent.com/40125720/197969607-e4986346-32ce-4efa-9935-45d199a791c4.png">
The requirement of an explicit version of `SyliusResourceBundle` should be removed after the release of `Sylius 1.12`

It also fixes an installation because of that change: https://github.com/Sylius/PayPalPlugin/pull/266