### PR TITLE
[docker] - Bug fix for cron container

### DIFF
--- a/docker/cron/crontab
+++ b/docker/cron/crontab
@@ -1,2 +1,2 @@
-* * * * * sh php bin/console sylius:remove-expired-carts
-* * * * * sh php bin/console sylius:sylius:cancel-unpaid-orders
+* * * * * php /srv/sylius/bin/console sylius:remove-expired-carts
+* * * * * php /srv/sylius/bin/console sylius:cancel-unpaid-orders


### PR DESCRIPTION
Specifying bin/console was not enough as crond process is global and does not use workdir. 