### PR TITLE
[Docker] Fix fixture images not being available #885

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -118,6 +118,15 @@ COPY --from=sylius_node /srv/sylius/public/build public/build
 
 FROM nginx:${NGINX_VERSION}-alpine AS sylius_nginx
 
+ARG GID=82
+ARG UID=82
+ARG USERNAME="www-data"
+
+RUN set -x; \
+    addgroup -g $GID -S $USERNAME; \
+    adduser -S -D -H -u $UID -h /var/cache/nginx -s /sbin/nologin -G $USERNAME -g $USERNAME $USERNAME
+
+COPY docker/nginx/nginx.conf /etc/nginx/nginx.conf
 COPY docker/nginx/conf.d/default.conf /etc/nginx/conf.d/
 
 WORKDIR /srv/sylius

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,14 @@ services:
       - DATABASE_URL=mysql://sylius:${MYSQL_PASSWORD:-nopassword}@mysql/sylius
       - LOAD_FIXTURES=1
       - PHP_DATE_TIMEZONE=${PHP_DATE_TIMEZONE:-UTC}
+    volumes:
+      - .:/srv/sylius:rw,cached
+      # if you develop on Linux, you may use a bind-mounted host directory instead
+      # - ./var:/srv/sylius/var:rw
+      - ./public:/srv/sylius/public:rw,delegated
+      # if you develop on Linux, you may use a bind-mounted host directory instead
+      # - ./public/media:/srv/sylius/public/media:rw
+      - public-media:/srv/sylius/public/media:rw
 
   mysql:
     container_name: mysql

--- a/docker/migrations/docker-entrypoint.sh
+++ b/docker/migrations/docker-entrypoint.sh
@@ -22,4 +22,7 @@ php bin/console doctrine:migrations:migrate --no-interaction
 
 if [ "$LOAD_FIXTURES" = "1" ]; then
     php bin/console sylius:fixtures:load --no-interaction
+
+    # make the image files created by fixtures accessible by fpm which runs with user www-data
+    chown -R www-data:www-data public/media/image
 fi

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,31 @@
+user  www-data;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    #gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
Fix #885

1. mount media volume to migrations container so fixture images are available in php and nginx container
2. change nginx user and group to match php's, so it can read image cache files