### PR TITLE
[Maintenance] Use PHP 8 attributes instead of annotations.

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -20,7 +20,7 @@ doctrine:
                 mappings:
                     App:
                         is_bundle: false
-                        type: annotation
+                        type: attribute
                         dir: '%kernel.project_dir%/src/Entity'
                         prefix: 'App\Entity'
                         alias: App

--- a/src/Entity/Addressing/Address.php
+++ b/src/Entity/Addressing/Address.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Address as BaseAddress;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_address")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_address')]
 class Address extends BaseAddress

--- a/src/Entity/Addressing/Country.php
+++ b/src/Entity/Addressing/Country.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\Country as BaseCountry;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_country")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_country')]
 class Country extends BaseCountry

--- a/src/Entity/Addressing/Province.php
+++ b/src/Entity/Addressing/Province.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\Province as BaseProvince;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_province")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_province')]
 class Province extends BaseProvince

--- a/src/Entity/Addressing/Zone.php
+++ b/src/Entity/Addressing/Zone.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\Zone as BaseZone;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_zone")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_zone')]
 class Zone extends BaseZone

--- a/src/Entity/Addressing/ZoneMember.php
+++ b/src/Entity/Addressing/ZoneMember.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\ZoneMember as BaseZoneMember;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_zone_member")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_zone_member')]
 class ZoneMember extends BaseZoneMember

--- a/src/Entity/Channel/Channel.php
+++ b/src/Entity/Channel/Channel.php
@@ -7,10 +7,6 @@ namespace App\Entity\Channel;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Channel as BaseChannel;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_channel")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_channel')]
 class Channel extends BaseChannel

--- a/src/Entity/Channel/ChannelPricing.php
+++ b/src/Entity/Channel/ChannelPricing.php
@@ -7,10 +7,6 @@ namespace App\Entity\Channel;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ChannelPricing as BaseChannelPricing;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_channel_pricing")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_channel_pricing')]
 class ChannelPricing extends BaseChannelPricing

--- a/src/Entity/Currency/Currency.php
+++ b/src/Entity/Currency/Currency.php
@@ -7,10 +7,6 @@ namespace App\Entity\Currency;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Currency\Model\Currency as BaseCurrency;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_currency")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_currency')]
 class Currency extends BaseCurrency

--- a/src/Entity/Currency/ExchangeRate.php
+++ b/src/Entity/Currency/ExchangeRate.php
@@ -7,10 +7,6 @@ namespace App\Entity\Currency;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Currency\Model\ExchangeRate as BaseExchangeRate;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_exchange_rate")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_exchange_rate')]
 class ExchangeRate extends BaseExchangeRate

--- a/src/Entity/Customer/Customer.php
+++ b/src/Entity/Customer/Customer.php
@@ -7,10 +7,6 @@ namespace App\Entity\Customer;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Customer as BaseCustomer;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_customer")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_customer')]
 class Customer extends BaseCustomer

--- a/src/Entity/Customer/CustomerGroup.php
+++ b/src/Entity/Customer/CustomerGroup.php
@@ -7,10 +7,6 @@ namespace App\Entity\Customer;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Customer\Model\CustomerGroup as BaseCustomerGroup;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_customer_group")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_customer_group')]
 class CustomerGroup extends BaseCustomerGroup

--- a/src/Entity/Locale/Locale.php
+++ b/src/Entity/Locale/Locale.php
@@ -7,10 +7,6 @@ namespace App\Entity\Locale;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Locale\Model\Locale as BaseLocale;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_locale")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_locale')]
 class Locale extends BaseLocale

--- a/src/Entity/Order/Adjustment.php
+++ b/src/Entity/Order/Adjustment.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Adjustment as BaseAdjustment;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_adjustment")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_adjustment')]
 class Adjustment extends BaseAdjustment

--- a/src/Entity/Order/Order.php
+++ b/src/Entity/Order/Order.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Order as BaseOrder;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order')]
 class Order extends BaseOrder

--- a/src/Entity/Order/OrderItem.php
+++ b/src/Entity/Order/OrderItem.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderItem as BaseOrderItem;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order_item")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order_item')]
 class OrderItem extends BaseOrderItem

--- a/src/Entity/Order/OrderItemUnit.php
+++ b/src/Entity/Order/OrderItemUnit.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderItemUnit as BaseOrderItemUnit;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order_item_unit")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order_item_unit')]
 class OrderItemUnit extends BaseOrderItemUnit

--- a/src/Entity/Order/OrderSequence.php
+++ b/src/Entity/Order/OrderSequence.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderSequence as BaseOrderSequence;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order_sequence")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order_sequence')]
 class OrderSequence extends BaseOrderSequence

--- a/src/Entity/Payment/GatewayConfig.php
+++ b/src/Entity/Payment/GatewayConfig.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Bundle\PayumBundle\Model\GatewayConfig as BaseGatewayConfig;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_gateway_config")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_gateway_config')]
 class GatewayConfig extends BaseGatewayConfig

--- a/src/Entity/Payment/Payment.php
+++ b/src/Entity/Payment/Payment.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Payment as BasePayment;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment')]
 class Payment extends BasePayment

--- a/src/Entity/Payment/PaymentMethod.php
+++ b/src/Entity/Payment/PaymentMethod.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\PaymentMethod as BasePaymentMethod;
 use Sylius\Component\Payment\Model\PaymentMethodTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment_method")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment_method')]
 class PaymentMethod extends BasePaymentMethod

--- a/src/Entity/Payment/PaymentMethodTranslation.php
+++ b/src/Entity/Payment/PaymentMethodTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Payment\Model\PaymentMethodTranslation as BasePaymentMethodTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment_method_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment_method_translation')]
 class PaymentMethodTranslation extends BasePaymentMethodTranslation

--- a/src/Entity/Payment/PaymentSecurityToken.php
+++ b/src/Entity/Payment/PaymentSecurityToken.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Bundle\PayumBundle\Model\PaymentSecurityToken as BasePaymentSecurityToken;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment_security_token")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment_security_token')]
 class PaymentSecurityToken extends BasePaymentSecurityToken

--- a/src/Entity/Product/Product.php
+++ b/src/Entity/Product/Product.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 use Sylius\Component\Product\Model\ProductTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product')]
 class Product extends BaseProduct

--- a/src/Entity/Product/ProductAssociation.php
+++ b/src/Entity/Product/ProductAssociation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAssociation as BaseProductAssociation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_association")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_association')]
 class ProductAssociation extends BaseProductAssociation

--- a/src/Entity/Product/ProductAssociationType.php
+++ b/src/Entity/Product/ProductAssociationType.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAssociationType as BaseProductAssociationType;
 use Sylius\Component\Product\Model\ProductAssociationTypeTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_association_type")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_association_type')]
 class ProductAssociationType extends BaseProductAssociationType

--- a/src/Entity/Product/ProductAssociationTypeTranslation.php
+++ b/src/Entity/Product/ProductAssociationTypeTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAssociationTypeTranslation as BaseProductAssociationTypeTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_association_type_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_association_type_translation')]
 class ProductAssociationTypeTranslation extends BaseProductAssociationTypeTranslation

--- a/src/Entity/Product/ProductAttribute.php
+++ b/src/Entity/Product/ProductAttribute.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Attribute\Model\AttributeTranslationInterface;
 use Sylius\Component\Product\Model\ProductAttribute as BaseProductAttribute;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_attribute")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_attribute')]
 class ProductAttribute extends BaseProductAttribute

--- a/src/Entity/Product/ProductAttributeTranslation.php
+++ b/src/Entity/Product/ProductAttributeTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAttributeTranslation as BaseProductAttributeTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_attribute_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_attribute_translation')]
 class ProductAttributeTranslation extends BaseProductAttributeTranslation

--- a/src/Entity/Product/ProductAttributeValue.php
+++ b/src/Entity/Product/ProductAttributeValue.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAttributeValue as BaseProductAttributeValue;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_attribute_value")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_attribute_value')]
 class ProductAttributeValue extends BaseProductAttributeValue

--- a/src/Entity/Product/ProductImage.php
+++ b/src/Entity/Product/ProductImage.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductImage as BaseProductImage;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_image")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_image')]
 class ProductImage extends BaseProductImage

--- a/src/Entity/Product/ProductOption.php
+++ b/src/Entity/Product/ProductOption.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOption as BaseProductOption;
 use Sylius\Component\Product\Model\ProductOptionTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option')]
 class ProductOption extends BaseProductOption

--- a/src/Entity/Product/ProductOptionTranslation.php
+++ b/src/Entity/Product/ProductOptionTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOptionTranslation as BaseProductOptionTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option_translation')]
 class ProductOptionTranslation extends BaseProductOptionTranslation

--- a/src/Entity/Product/ProductOptionValue.php
+++ b/src/Entity/Product/ProductOptionValue.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOptionValue as BaseProductOptionValue;
 use Sylius\Component\Product\Model\ProductOptionValueTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option_value")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option_value')]
 class ProductOptionValue extends BaseProductOptionValue

--- a/src/Entity/Product/ProductOptionValueTranslation.php
+++ b/src/Entity/Product/ProductOptionValueTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOptionValueTranslation as BaseProductOptionValueTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option_value_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option_value_translation')]
 class ProductOptionValueTranslation extends BaseProductOptionValueTranslation

--- a/src/Entity/Product/ProductReview.php
+++ b/src/Entity/Product/ProductReview.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductReview as BaseProductReview;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_review")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_review')]
 class ProductReview extends BaseProductReview

--- a/src/Entity/Product/ProductTaxon.php
+++ b/src/Entity/Product/ProductTaxon.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductTaxon as BaseProductTaxon;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_taxon")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_taxon')]
 class ProductTaxon extends BaseProductTaxon

--- a/src/Entity/Product/ProductTranslation.php
+++ b/src/Entity/Product/ProductTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductTranslation as BaseProductTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_translation')]
 class ProductTranslation extends BaseProductTranslation

--- a/src/Entity/Product/ProductVariant.php
+++ b/src/Entity/Product/ProductVariant.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductVariant as BaseProductVariant;
 use Sylius\Component\Product\Model\ProductVariantTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_variant")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_variant')]
 class ProductVariant extends BaseProductVariant

--- a/src/Entity/Product/ProductVariantTranslation.php
+++ b/src/Entity/Product/ProductVariantTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductVariantTranslation as BaseProductVariantTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_variant_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_variant_translation')]
 class ProductVariantTranslation extends BaseProductVariantTranslation

--- a/src/Entity/Promotion/CatalogPromotion.php
+++ b/src/Entity/Promotion/CatalogPromotion.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\CatalogPromotion as BaseCatalogPromotion;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_catalog_promotion")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_catalog_promotion')]
 class CatalogPromotion extends BaseCatalogPromotion

--- a/src/Entity/Promotion/CatalogPromotionAction.php
+++ b/src/Entity/Promotion/CatalogPromotionAction.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Promotion\Model\CatalogPromotionAction as BaseCatalogPromotionAction;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_catalog_promotion_action")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_catalog_promotion_action')]
 class CatalogPromotionAction extends BaseCatalogPromotionAction

--- a/src/Entity/Promotion/CatalogPromotionScope.php
+++ b/src/Entity/Promotion/CatalogPromotionScope.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\CatalogPromotionScope as BaseCatalogPromotionScope;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_catalog_promotion_scope")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_catalog_promotion_scope')]
 class CatalogPromotionScope extends BaseCatalogPromotionScope

--- a/src/Entity/Promotion/Promotion.php
+++ b/src/Entity/Promotion/Promotion.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Promotion as BasePromotion;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion')]
 class Promotion extends BasePromotion

--- a/src/Entity/Promotion/PromotionAction.php
+++ b/src/Entity/Promotion/PromotionAction.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Promotion\Model\PromotionAction as BasePromotionAction;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion_action")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion_action')]
 class PromotionAction extends BasePromotionAction

--- a/src/Entity/Promotion/PromotionCoupon.php
+++ b/src/Entity/Promotion/PromotionCoupon.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\PromotionCoupon as BasePromotionCoupon;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion_coupon")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion_coupon')]
 class PromotionCoupon extends BasePromotionCoupon

--- a/src/Entity/Promotion/PromotionRule.php
+++ b/src/Entity/Promotion/PromotionRule.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Promotion\Model\PromotionRule as BasePromotionRule;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion_rule")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion_rule')]
 class PromotionRule extends BasePromotionRule

--- a/src/Entity/Shipping/Shipment.php
+++ b/src/Entity/Shipping/Shipment.php
@@ -7,10 +7,6 @@ namespace App\Entity\Shipping;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Shipment as BaseShipment;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipment")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipment')]
 class Shipment extends BaseShipment

--- a/src/Entity/Shipping/ShippingCategory.php
+++ b/src/Entity/Shipping/ShippingCategory.php
@@ -7,10 +7,6 @@ namespace App\Entity\Shipping;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Shipping\Model\ShippingCategory as BaseShippingCategory;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipping_category")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipping_category')]
 class ShippingCategory extends BaseShippingCategory

--- a/src/Entity/Shipping/ShippingMethod.php
+++ b/src/Entity/Shipping/ShippingMethod.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ShippingMethod as BaseShippingMethod;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipping_method")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipping_method')]
 class ShippingMethod extends BaseShippingMethod

--- a/src/Entity/Shipping/ShippingMethodTranslation.php
+++ b/src/Entity/Shipping/ShippingMethodTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Shipping;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslation as BaseShippingMethodTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipping_method_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipping_method_translation')]
 class ShippingMethodTranslation extends BaseShippingMethodTranslation

--- a/src/Entity/Taxation/TaxCategory.php
+++ b/src/Entity/Taxation/TaxCategory.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxation;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Taxation\Model\TaxCategory as BaseTaxCategory;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_tax_category")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_tax_category')]
 class TaxCategory extends BaseTaxCategory

--- a/src/Entity/Taxation/TaxRate.php
+++ b/src/Entity/Taxation/TaxRate.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxation;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\TaxRate as BaseTaxRate;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_tax_rate")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_tax_rate')]
 class TaxRate extends BaseTaxRate

--- a/src/Entity/Taxonomy/Taxon.php
+++ b/src/Entity/Taxonomy/Taxon.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Taxon as BaseTaxon;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_taxon")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_taxon')]
 class Taxon extends BaseTaxon

--- a/src/Entity/Taxonomy/TaxonImage.php
+++ b/src/Entity/Taxonomy/TaxonImage.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxonomy;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\TaxonImage as BaseTaxonImage;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_taxon_image")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_taxon_image')]
 class TaxonImage extends BaseTaxonImage

--- a/src/Entity/Taxonomy/TaxonTranslation.php
+++ b/src/Entity/Taxonomy/TaxonTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxonomy;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Taxonomy\Model\TaxonTranslation as BaseTaxonTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_taxon_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_taxon_translation')]
 class TaxonTranslation extends BaseTaxonTranslation

--- a/src/Entity/User/AdminUser.php
+++ b/src/Entity/User/AdminUser.php
@@ -7,10 +7,6 @@ namespace App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\AdminUser as BaseAdminUser;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_admin_user")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_admin_user')]
 class AdminUser extends BaseAdminUser

--- a/src/Entity/User/ShopUser.php
+++ b/src/Entity/User/ShopUser.php
@@ -7,10 +7,6 @@ namespace App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ShopUser as BaseShopUser;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shop_user")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shop_user')]
 class ShopUser extends BaseShopUser

--- a/src/Entity/User/UserOAuth.php
+++ b/src/Entity/User/UserOAuth.php
@@ -7,10 +7,6 @@ namespace App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\User\Model\UserOAuth as BaseUserOAuth;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_user_oauth")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_user_oauth')]
 class UserOAuth extends BaseUserOAuth


### PR DESCRIPTION
Doctrine annotations are deprecated in favor of native PHP 8 attributes.