### PR TITLE
[Docker] configuration: fix mailer dsn

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - APP_DEBUG=1
       - APP_SECRET=EDITME
       - DATABASE_URL=mysql://sylius:${MYSQL_PASSWORD:-nopassword}@mysql/sylius
-      - MAILER_URL=smtp://mailhog:1025
+      - MAILER_DSN=smtp://mailhog:1025
       - PHP_DATE_TIMEZONE=${PHP_DATE_TIMEZONE:-UTC}
     volumes:
       - .:/srv/sylius:rw,cached


### PR DESCRIPTION
Mailhog doesn't capture the e-mails because of a configuration issue in `docker-compose.yml`

the `MAILER_URL` environment variable should be replaced with `MAILER_DSN`