### PR TITLE
[Config] Move the database config into .env connection string

### DIFF
--- a/.env
+++ b/.env
@@ -9,11 +9,11 @@ APP_SECRET=EDITME
 ###< symfony/framework-bundle ###
 
 ###> doctrine/doctrine-bundle ###
-# Format described at http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#connecting-using-a-url
-# For a sqlite database, use: "sqlite:///%kernel.project_dir%/var/data.db"
-# Set "serverVersion" to your server version to avoid edge-case exceptions and extra database calls
-DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%
+# Choose one of the following DBMS, adjust the server version and charset if needed
+DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%?serverVersion=8&charset=utf8mb4
+#DATABASE_URL=pgsql://postgres:postgres@127.0.0.1/sylius_%kernel.environment%?serverVersion=15&charset=utf8
 ###< doctrine/doctrine-bundle ###
+
 ###> symfony/messenger ###
 # Choose one of the transports below
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -7,11 +7,8 @@ parameters:
 
 doctrine:
     dbal:
-        driver: 'pdo_mysql'
-        server_version: '8.0'
-        charset: utf8mb4
-
         url: '%env(resolve:DATABASE_URL)%'
+
     orm:
         auto_generate_proxy_classes: '%kernel.debug%'
         entity_managers:


### PR DESCRIPTION
Moving this config prevents a container compilation error when using PostgreSQL

Refs:
https://github.com/Sylius/Sylius/issues/11851

https://github.com/Sylius/Sylius/pull/14950
https://github.com/Sylius/Sylius/pull/14925