### PR TITLE
Use sodium value for password hashers

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -10,7 +10,7 @@ security:
         sylius_api_shop_user_provider:
             id: sylius.shop_user_provider.email_or_name_based
     password_hashers:
-        Sylius\Component\User\Model\UserInterface: argon2i
+        Sylius\Component\User\Model\UserInterface: sodium
     firewalls:
         admin:
             switch_user: true


### PR DESCRIPTION
It's a bit old but since Symfony 4.3, using sodium value is a safe way to let the system pick the best argon algorithm available with no danger or update path.

https://symfony.com/blog/new-in-symfony-4-3-sodium-password-encoder