### PR TITLE
[CI][Maintenance] Remove PHP 8.0 and add PHP 8.2 to workflow, Bump minimum PHP version to 8.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.0", "8.1"]
+                php: ["8.1", "8.2"]
                 symfony: ["^5.4", "^6.0"]
                 node: ["16.x"]
                 mysql: ["5.7", "8.0"]

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "sylius/paypal-plugin": "^1.5",
         "sylius/sylius": "^1.12",
         "symfony/dotenv": "^5.4 || ^6.0",


### PR DESCRIPTION
PHP 8.0 is not actively supported and its security support will end in two months (25 Nov 2023).
It's time to move forward

Ref:
https://www.php.net/supported-versions.php