### PR TITLE
[Readme] Reference current version in installation doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ symfony serve
 $ open http://localhost:8000/
 ```
 
-For more detailed instruction please visit [installation chapter in our docs](https://docs.sylius.com/en/1.10/book/installation/installation.html).
+For more detailed instruction please visit [installation chapter in our docs](https://docs.sylius.com/en/latest/book/installation/installation.html).
 
 ### Docker
 


### PR DESCRIPTION
Currently the readme links to the 1.10 docs. I think pointing directly to `current` is probably the better option than 1.12, because it will always link to the latest version.