### PR TITLE
Removed duplicate Paths to api_platform.yaml

### DIFF
--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -1,7 +1,6 @@
 api_platform:
     mapping:
         paths:
-            - '%kernel.project_dir%/vendor/sylius/sylius/src/Sylius/Bundle/ApiBundle/Resources/config/api_resources'
             - '%kernel.project_dir%/config/api_platform'
             - '%kernel.project_dir%/src/Entity'
     patch_formats:


### PR DESCRIPTION
Removed duplicate Paths to api_platform.yaml because now the path is added to the class SyliusApiExtension method prependApiPlatformMapping