### PR TITLE
[Maintenance] Bump minimal `Symfony` version from `6.0` to `6.4`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
                 exclude:
                     -
                         php: "8.0"
-                        symfony: "^6.0"
+                        symfony: "^6.4"
 
         env:
             APP_ENV: test_cached

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
             fail-fast: false
             matrix:
                 php: ["8.0", "8.1"]
-                symfony: ["^5.4", "^6.0"]
+                symfony: ["^5.4", "^6.4"]
                 node: ["16.x"]
                 mysql: ["5.7", "8.0"]
                 exclude:

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         "php": "^8.0",
         "sylius/paypal-plugin": "^1.5",
         "sylius/sylius": "^1.12.11",
-        "symfony/dotenv": "^5.4 || ^6.0",
-        "symfony/runtime": "^5.4 || ^6.0",
+        "symfony/dotenv": "^5.4 || ^6.4",
+        "symfony/runtime": "^5.4 || ^6.4",
         "symfony/flex": "^2.4"
     },
     "require-dev": {
@@ -55,10 +55,10 @@
         "stripe/stripe-php": "^6.43",
         "sylius-labs/coding-standard": "^4.0",
         "sylius/sylius-rector": "^1.0",
-        "symfony/browser-kit": "^5.4 || ^6.0",
-        "symfony/debug-bundle": "^5.4 || ^6.0",
-        "symfony/intl": "^5.4 || ^6.0",
-        "symfony/web-profiler-bundle": "^5.4 || ^6.0"
+        "symfony/browser-kit": "^5.4 || ^6.4",
+        "symfony/debug-bundle": "^5.4 || ^6.4",
+        "symfony/intl": "^5.4 || ^6.4",
+        "symfony/web-profiler-bundle": "^5.4 || ^6.4"
     },
     "conflict": {
         "symfony/framework-bundle": "6.2.8",
@@ -83,7 +83,7 @@
         },
         "symfony": {
             "allow-contrib": false,
-            "require": "^6.0",
+            "require": "^6.4",
             "endpoint": [
                 "https://api.github.com/repos/Sylius/SyliusRecipes/contents/index.json?ref=flex/main",
                 "flex://defaults"


### PR DESCRIPTION
Symfony 6.4 has been released and it is LTS version, so we should bump the minimum version constraint
https://symfony.com/releases/6.4