### PR TITLE
Conflict `behat/mink-selenium2-driver:>=1.7.0`

### DIFF
--- a/CONFLICTS.md
+++ b/CONFLICTS.md
@@ -5,5 +5,11 @@ references related issues.
 
 - `symfony/framework-bundle:6.2.8`:
 
-  This version is missing the service alias `validator.expression`
-  which causes ValidatorException exception to be thrown when using `Expression` constraint. 
+    This version is missing the service alias `validator.expression`
+    which causes ValidatorException exception to be thrown when using `Expression` constraint. 
+
+- `behat/mink-selenium2-driver:>=1.7.0`:
+
+    This version adds strict type to the `Behat\Mink\Driver\Selenium2Driver::visit($url)` method
+    which causes a fatal error because the method signature is no longer compatible with the parent class:
+    `PHP Fatal error:  Declaration of Behat\Mink\Driver\Selenium2Driver::visit(string $url) must be compatible with Behat\Mink\Driver\CoreDriver::visit($url) in /home/runner/work/Sylius-Standard/Sylius-Standard/vendor/behat/mink-selenium2-driver/src/Selenium2Driver.php on line 401`

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,8 @@
         "symfony/web-profiler-bundle": "^5.4 || ^6.0"
     },
     "conflict": {
-        "symfony/framework-bundle": "6.2.8"
+        "symfony/framework-bundle": "6.2.8",
+        "behat/mink-selenium2-driver": ">=1.7.0"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
This version adds strict type to the `Behat\Mink\Driver\Selenium2Driver::visit($url)` method which causes a fatal error because the method signature is no longer compatible with the parent 