### PR TITLE
[Maintenance] Bump `sylius/sylius-rector` Package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
         "robertfausk/behat-panther-extension": "^1.1",
         "stripe/stripe-php": "^6.43",
         "sylius-labs/coding-standard": "^4.0",
-        "sylius/sylius-rector": "^1.0",
+        "sylius/sylius-rector": "^2.0",
         "symfony/browser-kit": "^5.4 || ^6.4",
         "symfony/debug-bundle": "^5.4 || ^6.4",
         "symfony/intl": "^5.4 || ^6.4",


### PR DESCRIPTION
In the `sylius/sylius-rector ^2.0` package, `rector/rector` dependency is now a hard dependency and no longer needs to be explicitly required in the end app.