### PR TITLE
Fix error during template install

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -60,4 +60,5 @@ return [
     SyliusLabs\Polyfill\Symfony\Security\Bundle\SyliusLabsPolyfillSymfonySecurityBundle::class => ['all' => true],
     League\FlysystemBundle\FlysystemBundle::class => ['all' => true],
     Symfony\WebpackEncoreBundle\WebpackEncoreBundle::class => ['all' => true],
+    Sylius\Abstraction\StateMachine\SyliusStateMachineAbstractionBundle::class => ['all' => true],
 ];


### PR DESCRIPTION
Fixes bug during installation and enables the missing "sylius_abstraction.state_machine" service.

During installation of a clean Sylius using 
`composer create-project sylius/sylius-standard MyFirstShop`
an error occurs because of the missing sylius_abstraction.state_machine service definition.

```
!!  In CheckExceptionOnInvalidReferenceBehaviorPass.php line 119:
!!                                                                                                                       
!!    The service "sylius.fixture.order" has a dependency on a non-existent service "sylius_abstraction.state_machine". 
```

This MR fixes this behaviour.