### PR TITLE
[Maintenance] Require precise packages instead of generic sylius/sylius

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,9 @@
     "require": {
         "php": "^8.1",
         "sylius/paypal-plugin": "^1.6",
-        "sylius/sylius": "~1.13.0",
+        "sylius/admin-bundle": "~1.13.0",
+        "sylius/shop-bundle": "~1.13.0",
+        "sylius/api-bundle": "~1.13.0",
         "symfony/dotenv": "^5.4 || ^6.4",
         "symfony/flex": "^2.4",
         "symfony/runtime": "^5.4 || ^6.4"


### PR DESCRIPTION
I propose switching from the generic "sylius/sylius" dependency to a set of high-level, more explicit ones. Of course, I would like to require "sylius/core-bundle" - as it is the core and heart of Sylius itself. In addition, with this change, we will require:

*  "sylius/admin-bundle"
* "sylius/shop-bundle" 
* "sylius/api-bundle"

These packages should be considered as a default stack of Sylius at the moment. What is missing from this list? Deprecated admin-api, but that should be considered as a benefit of this change.

In addition what we are earning with it is the fact that if in the future we will add a new layer to Sylius it won't be automatically propagated to all existing shops. Also, we are making it easier for people to turn off one of the accessing layers to Sylius