### PR TITLE
[Maintenance] Bump PHP and Symfony dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                php: ["8.1", "8.2"]
-                symfony: ["^5.4", "^6.4"]
+                php: ["8.3"]
+                symfony: ["^6.4"]
                 node: ["20.x"]
                 mysql: ["8.3"]
 

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
         }
     ],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "sylius/paypal-plugin": "^1.6",
         "sylius/sylius": "~1.13.0",
-        "symfony/dotenv": "^5.4 || ^6.4",
+        "symfony/dotenv": "^6.4",
         "symfony/flex": "^2.4",
-        "symfony/runtime": "^5.4 || ^6.4"
+        "symfony/runtime": "^6.4"
     },
     "require-dev": {
         "behat/behat": "^3.7",
@@ -58,10 +58,10 @@
         "sylius-labs/coding-standard": "^4.0",
         "sylius-labs/suite-tags-extension": "^0.1.0",
         "sylius/sylius-rector": "^2.0",
-        "symfony/browser-kit": "^5.4 || ^6.4",
-        "symfony/debug-bundle": "^5.4 || ^6.4",
-        "symfony/intl": "^5.4 || ^6.4",
-        "symfony/web-profiler-bundle": "^5.4 || ^6.4"
+        "symfony/browser-kit": "^6.4",
+        "symfony/debug-bundle": "^6.4",
+        "symfony/intl": "^6.4",
+        "symfony/web-profiler-bundle": "^6.4"
     },
     "conflict": {
         "symfony/framework-bundle": "6.2.8",
@@ -83,7 +83,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-main": "1.13-dev"
+            "dev-main": "1.14-dev"
         },
         "symfony": {
             "allow-contrib": false,


### PR DESCRIPTION
Hello there!

My next proposal concerns bumping requirements in Sylius-Standard. I propose requiring only the latest version of PHP and Symfony for the current version. There is no need to require a lower version of these packages. No one would like to use older Symfony LTS just for the sake of it. And with Flex as a hard dependency, we are installing Symfony 6.4 anyway. 

With PHP it is almost the same. Plus, a composer will sort out which version of Sylius-Standard it should use on its own 