### PR TITLE
[Maintenance] Switch default doctrine mapping to attributes

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -17,7 +17,7 @@ doctrine:
                 mappings:
                     App:
                         is_bundle: false
-                        type: annotation
+                        type: attribute
                         dir: '%kernel.project_dir%/src/Entity'
                         prefix: 'App\Entity'
                         alias: App


### PR DESCRIPTION
Attributes are with us for a long time. From Sylius 2.0, attributes will be favourited over annotation (even tho the core of Sylius will remain XML-based).

To push our community into that direction, I'm proposing to change our template to use attributes by default so we increase its adoption over time