### PR TITLE
Cart quantity field

### DIFF
--- a/.env
+++ b/.env
@@ -10,7 +10,8 @@ APP_SECRET=EDITME
 
 ###> doctrine/doctrine-bundle ###
 # Choose one of the following DBMS, adjust the server version and charset if needed
-DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%?serverVersion=8&charset=utf8mb4
+#DATABASE_URL=mysql://root@127.0.0.1/sylius_%kernel.environment%?serverVersion=8&charset=utf8mb4
+DATABASE_URL=mysql://azaria:@Talmud89@127.0.0.1/sylius_%kernel.environment%?serverVersion=8&charset=utf8mb4
 #DATABASE_URL=pgsql://postgres:postgres@127.0.0.1/sylius_%kernel.environment%?serverVersion=15&charset=utf8
 ###< doctrine/doctrine-bundle ###
 

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "sylius/sylius": "~1.13.0",
         "symfony/dotenv": "^5.4 || ^6.4",
         "symfony/flex": "^2.4",
-        "symfony/runtime": "^5.4 || ^6.4"
+        "symfony/runtime": "^7.1"
     },
     "require-dev": {
         "behat/behat": "^3.7",

--- a/templates/bundles/SyliusShopBundle/Product/show.html.twig
+++ b/templates/bundles/SyliusShopBundle/Product/show.html.twig
@@ -12,15 +12,6 @@
     </div>
     <div class="column" {{ sylius_test_html_attribute('product-box') }}>
         {{ sylius_template_event('sylius.shop.product.show.right_sidebar', _context) }}
-         <script>
-         const inputInterger = document.querySelector("#sylius_add_to_cart_cartItem_quantity");
-         inputInterger.min = 10;
-         inputInterger.value = 10;
-         inputInterger.step=10;
-         inputInterger.addEventListener('change',(e)=>{
-            if(e.target.value==="70") alert("Great Choice!")
-         },false)
-         </script>
     </div>
 </div>
 
@@ -34,5 +25,12 @@
     lightbox.option({
         'albumLabel': '{{ 'sylius.lightbox.image_album_label'|trans|escape('js') }}'
     });
+    const inputInterger = document.querySelector("#sylius_add_to_cart_cartItem_quantity");
+    inputInterger.min = 10;
+    inputInterger.value = 10;
+    inputInterger.step=10;
+    inputInterger.addEventListener('change',(e)=>{
+      if(e.target.value==="70") alert("Great Choice!")
+    },false)
 </script>
 {% endblock %}

--- a/templates/bundles/SyliusShopBundle/Product/show.html.twig
+++ b/templates/bundles/SyliusShopBundle/Product/show.html.twig
@@ -1,0 +1,38 @@
+{% extends '@SyliusShop/layout.html.twig' %}
+
+{% block title %}{{ product.name }} | {{ parent() }}{% endblock %}
+
+{% block content %}
+{% include '@SyliusShop/Product/Show/_breadcrumb.html.twig' %}
+<div class="ui hidden divider"></div>
+
+<div class="ui two column stackable grid">
+    <div class="column">
+        {{ sylius_template_event('sylius.shop.product.show.left_sidebar', _context) }}
+    </div>
+    <div class="column" {{ sylius_test_html_attribute('product-box') }}>
+        {{ sylius_template_event('sylius.shop.product.show.right_sidebar', _context) }}
+         <script>
+         const inputInterger = document.querySelector("#sylius_add_to_cart_cartItem_quantity");
+         inputInterger.min = 10;
+         inputInterger.value = 10;
+         inputInterger.step=10;
+         inputInterger.addEventListener('change',(e)=>{
+            if(e.target.value==="70") alert("Great Choice!")
+         },false)
+         </script>
+    </div>
+</div>
+
+{{ sylius_template_event('sylius.shop.product.show.content', _context) }}
+{% endblock %}
+
+{% block javascripts %}
+{{ parent() }}
+
+<script type="text/javascript">
+    lightbox.option({
+        'albumLabel': '{{ 'sylius.lightbox.image_album_label'|trans|escape('js') }}'
+    });
+</script>
+{% endblock %}


### PR DESCRIPTION
# In that pull request I have:

- Fork and Clone the Sylius Standard Repository

- Modify Cart Quantity Field:
 - Adjust the "quantity" field in the cart forms on the product pages.
- Change the step increment from 1 to 10, starting at 10.

This means the quantities available should be 10, 20, 30, and so on, instead of the default 1, 2, 3, etc.

- Additional Task (Optional):
  1. If the user selects a quantity of 70, display a plain JavaScript alert with the message "Great Choice!".

<b>NB</b>: There are many solutions for this problem, but I've chosen to override a specific template and put a javascript code, thus I'll not modify many templates either.

