### PR TITLE
Add support for docker Compose V2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,13 @@ DOCKER_USER ?= "$(shell id -u):$(shell id -g)"
 ENV ?= "dev"
 
 init:
+	@make -s docker-compose-check
 	@if [ ! -e compose.override.yml ]; then \
 		cp compose.override.dist.yml compose.override.yml; \
 	fi
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm php composer install --no-interaction --no-scripts
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm nodejs
-	make install
+	@make -s install
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) up -d
 
 run:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: run
 
+DOCKER_COMPOSE ?= docker compose
 DOCKER_USER ?= "$(shell id -u):$(shell id -g)"
 ENV ?= "dev"
 
@@ -7,34 +8,39 @@ init:
 	@if [ ! -e compose.override.yml ]; then \
 		cp compose.override.dist.yml compose.override.yml; \
 	fi
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose run --rm php composer install --no-interaction --no-scripts
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose run --rm nodejs
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm php composer install --no-interaction --no-scripts
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm nodejs
 	make install
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose up -d
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) up -d
 
 run:
 	make up
 
 debug:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose -f compose.yml -f compose.override.yml -f compose.debug.yml up -d
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) -f compose.yml -f compose.override.yml -f compose.debug.yml up -d
 
 up:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose up -d
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) up -d
 
 down:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose down
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) down
 
 install:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose run --rm php bin/console sylius:install -s default -n
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm php bin/console sylius:install -s default -n
 
 clean:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose down -v
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) down -v
 
 php-shell:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose exec php sh
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) exec php sh
 
 node-shell:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose run --rm -i nodejs sh
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm -i nodejs sh
 
 node-watch:
-	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) docker-compose run --rm -i nodejs "npm run watch"
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm -i nodejs "npm run watch"
+
+docker-compose-check:
+	@which $(DOCKER_COMPOSE) > /dev/null || (echo "Please install docker compose binary" && exit 1)
+	@echo "You are using \"$(DOCKER_COMPOSE)\" binary"
+	@echo "Current version is \"$$($(DOCKER_COMPOSE) version)\""

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ init:
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) up -d
 
 run:
-	make up
+	@make -s up
 
 debug:
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) -f compose.yml -f compose.override.yml -f compose.debug.yml up -d


### PR DESCRIPTION
To change or to use the fallback version add to terminal configuration:
```sh
export DOCKER_COMPOSE="docker-compose"
```

resolve #986