### PR TITLE
Integrate Sylius Cloud by standard Symfony installer

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -100,6 +100,7 @@ hooks:
         hash -r
         yarn install --frozen-lockfile
         yarn build:prod
+        symfony-build
 
     deploy: |
         set -e

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -94,19 +94,23 @@ crons:
 
 hooks:
     build: |
-        set -e 
-        curl -fs https://get.symfony.com/cloud/configurator | bash
+        set -e
         n auto
         hash -r
+        curl -sS https://get.symfony.com/cli/installer | bash
+        mv "$PLATFORM_APP_DIR/.symfony5/bin/symfony" "$PLATFORM_APP_DIR/.global/bin/symfony"
+        cat >> "$PLATFORM_APP_DIR/.global/environment" <<EOS
+            export \$(symfony var:export)
+        EOS
         yarn install --frozen-lockfile
         yarn build:prod
-        symfony-build
 
     deploy: |
         set -e
-        symfony-deploy
         rm -rf var/cache/*
         mkdir -p public/media/image
+        bin/console doctrine:database:create --if-not-exists
+        bin/console doctrine:schema:update --force
         bin/console sylius:fixtures:load -n
         bin/console lexik:jwt:generate-keypair --skip-if-exists
         bin/console assets:install --symlink --relative public

--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -110,7 +110,7 @@ hooks:
         rm -rf var/cache/*
         mkdir -p public/media/image
         bin/console doctrine:database:create --if-not-exists
-        bin/console doctrine:schema:update --force
+        bin/console doctrine:migrations:migrate -n
         bin/console sylius:fixtures:load -n
         bin/console lexik:jwt:generate-keypair --skip-if-exists
         bin/console assets:install --symlink --relative public


### PR DESCRIPTION
The Symfony integration seems not to be a correct way to do the Sylius Cloud integration. I've replaced it with standard Symfony installer.

I've tested this on a new environment and it works correctly.