### PR TITLE
[Maintenance] Upgrade Recipes & Refine Project Structure

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -75,7 +75,7 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[phpstan.neon]
+[phpstan.dist.neon]
 indent_style = space
 indent_size = 4
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -75,10 +75,6 @@ indent_size = 4
 indent_style = space
 indent_size = 2
 
-[phpspec.yml{,.dist}]
-indent_style = space
-indent_size = 4
-
 [phpstan.neon]
 indent_style = space
 indent_size = 4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -171,7 +171,7 @@ jobs:
 
             -
                 name: Run PHPStan
-                run: vendor/bin/phpstan analyse -c phpstan.neon -l max src/
+                run: vendor/bin/phpstan analyse -c phpstan.dist.neon -l max src/
 
             -
                 name: Validate database schema

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -178,10 +178,6 @@ jobs:
                 run: bin/console doctrine:schema:validate
 
             -
-                name: Run PHPSpec
-                run: vendor/bin/phpspec run --ansi -f progress --no-interaction
-
-            -
                 name: Run PHPUnit
                 run: vendor/bin/phpunit --colors=always
 

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,11 @@
 ###> phpstan/phpstan ###
 phpstan.neon
 ###< phpstan/phpstan ###
+
+###> friends-of-behat/symfony-extension ###
+/behat.yml
+###< friends-of-behat/symfony-extension ###
+
+###> liip/imagine-bundle ###
+/public/media/cache/
+###< liip/imagine-bundle ###

--- a/.gitignore
+++ b/.gitignore
@@ -8,8 +8,6 @@
 /etc/build/*
 !/etc/build/.gitignore
 
-/behat.yml
-
 /drivers/
 
 /docker-compose.override.yaml
@@ -51,3 +49,7 @@
 /yarn.lock
 /package-lock.json
 ###< symfony/webpack-encore-bundle ###
+
+###> phpstan/phpstan ###
+phpstan.neon
+###< phpstan/phpstan ###

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@
 !/etc/build/.gitignore
 
 /behat.yml
-/phpspec.yml
 
 /drivers/
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Enjoy being an eCommerce Developer again!
 
 Powerful REST API allows for easy integrations and creating unique customer experience on any device.
 
-We're using full-stack Behavior-Driven-Development, with [phpspec](http://phpspec.net) and [Behat](http://behat.org)
+We're using full-stack Behavior-Driven-Development, with [Behat](http://behat.org)
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require-dev": {
         "behat/behat": "^3.7",
         "behat/mink-selenium2-driver": "^1.4",
-        "dbrekelmans/bdi": "^1.1",
+        "dbrekelmans/bdi": "^1.3",
         "dmore/behat-chrome-extension": "^1.3",
         "dmore/chrome-mink-driver": "^2.7",
         "friends-of-behat/mink": "^1.8",

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,6 @@
         "phpstan/phpstan-doctrine": "^1.3.2",
         "phpstan/phpstan-webmozart-assert": "^1.1",
         "phpunit/phpunit": "^10.5",
-        "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "robertfausk/behat-panther-extension": "^1.1",
         "sylius-labs/coding-standard": "^4.0",
         "sylius-labs/suite-tags-extension": "^0.2",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,6 @@
         "friends-of-behat/variadic-extension": "^1.3",
         "lchrusciel/api-test-case": "^5.0",
         "nyholm/psr7": "^1.8",
-        "phpspec/phpspec": "^7.0",
         "phpstan/extension-installer": "^1.0",
         "phpstan/phpstan": "^1.8.4",
         "phpstan/phpstan-doctrine": "^1.3.2",

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,25 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 use Symfony\Component\Dotenv\Dotenv;
 
-require dirname(__DIR__).'/vendor/autoload.php';
+require dirname(__DIR__) . '/vendor/autoload.php';
 
 // Load cached env vars if the .env.local.php file exists
 // Run "composer dump-env prod" to create it (requires symfony/flex >=1.2)
-if (is_array($env = @include dirname(__DIR__).'/.env.local.php')) {
+if (is_array($env = @include dirname(__DIR__) . '/.env.local.php')) {
     $_SERVER += $env;
     $_ENV += $env;
 } elseif (!class_exists(Dotenv::class)) {
     throw new RuntimeException('Please run "composer require symfony/dotenv" to load the ".env" files configuring the application.');
-} elseif (method_exists(Dotenv::class, 'bootEnv')) {
-    (new Dotenv())->bootEnv(dirname(__DIR__) . '/.env');
-
-    return;
 } else {
     // load all the .env files
-    (new Dotenv(true))->loadEnv(dirname(__DIR__).'/.env');
+    (new Dotenv())->loadEnv(dirname(__DIR__) . '/.env');
 }
 
 $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int) $_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], \FILTER_VALIDATE_BOOLEAN) ? '1' : '0';

--- a/config/packages/api_platform.yaml
+++ b/config/packages/api_platform.yaml
@@ -3,6 +3,7 @@ api_platform:
         paths:
             - '%kernel.project_dir%/config/api_platform'
             - '%kernel.project_dir%/src/Entity'
+            - '%kernel.project_dir%/src/ApiResource'
     patch_formats:
         json: ['application/merge-patch+json']
     swagger:

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -1,0 +1,19 @@
+framework:
+    cache:
+        # Unique name of your app: used to compute stable namespaces for cache keys.
+        #prefix_seed: your_vendor_name/app_name
+
+        # The "app" cache stores to the filesystem by default.
+        # The data in this cache should persist between deploys.
+        # Other options include:
+
+        # Redis
+        #app: cache.adapter.redis
+        #default_redis_provider: redis://localhost
+
+        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
+        #app: cache.adapter.apcu
+
+        # Namespaced pools use the above "app" backend by default
+        #pools:
+            #my.dedicated.cache: null

--- a/config/packages/debug.yaml
+++ b/config/packages/debug.yaml
@@ -1,0 +1,5 @@
+when@dev:
+    debug:
+        # Forwards VarDumper Data clones to a centralized server allowing to inspect dumps on CLI or in your browser.
+        # See the "server:dump" command to start a new server.
+        dump_destination: "tcp://%env(VAR_DUMPER_SERVER)%"

--- a/config/packages/doctrine_migrations.yaml
+++ b/config/packages/doctrine_migrations.yaml
@@ -3,4 +3,7 @@ doctrine_migrations:
         table_storage:
             table_name: sylius_migrations
     migrations_paths:
-        'App\Migrations': "%kernel.project_dir%/src/Migrations"
+        # namespace is arbitrary but should be different from App\Migrations
+        # as migrations classes should NOT be autoloaded
+        'App': '%kernel.project_dir%/migrations'
+    enable_profiler: false

--- a/config/packages/messenger.yaml
+++ b/config/packages/messenger.yaml
@@ -1,0 +1,22 @@
+framework:
+    messenger:
+        # Uncomment this (and the failed transport below) to send failed messages to this transport for later handling.
+        # failure_transport: failed
+
+        transports:
+            # https://symfony.com/doc/current/messenger.html#transport-configuration
+            # async: '%env(MESSENGER_TRANSPORT_DSN)%'
+            # failed: 'doctrine://default?queue_name=failed'
+            # sync: 'sync://'
+
+        routing:
+            # Route your messages to the transports
+            # 'App\Message\YourMessage': async
+
+# when@test:
+#    framework:
+#        messenger:
+#            transports:
+#                # replace with your transport name here (e.g., my_transport: 'in-memory://')
+#                # For more Messenger testing tools, see https://github.com/zenstruck/messenger-test
+#                async: 'in-memory://'

--- a/config/packages/monolog.yaml
+++ b/config/packages/monolog.yaml
@@ -1,0 +1,61 @@
+monolog:
+    channels:
+        - deprecation # Deprecations are logged in the dedicated "deprecation" channel when it exists
+
+when@dev:
+    monolog:
+        handlers:
+            main:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: debug
+                channels: ["!event"]
+            # uncomment to get logging in your browser
+            # you may have to allow bigger header sizes in your Web server configuration
+            #firephp:
+            #    type: firephp
+            #    level: info
+            #chromephp:
+            #    type: chromephp
+            #    level: info
+            console:
+                type: console
+                process_psr_3_messages: false
+                channels: ["!event", "!doctrine", "!console"]
+
+when@test:
+    monolog:
+        handlers:
+            main:
+                type: fingers_crossed
+                action_level: error
+                handler: nested
+                channels: ["!event"]
+            nested:
+                type: stream
+                path: "%kernel.logs_dir%/%kernel.environment%.log"
+                level: debug
+
+when@prod:
+    monolog:
+        handlers:
+            main:
+                type: fingers_crossed
+                action_level: error
+                handler: nested
+                excluded_http_codes: [404, 405]
+                buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+            nested:
+                type: stream
+                path: php://stderr
+                level: debug
+                formatter: monolog.formatter.json
+            console:
+                type: console
+                process_psr_3_messages: false
+                channels: ["!event", "!doctrine"]
+            deprecation:
+                type: stream
+                channels: [deprecation]
+                path: php://stderr
+                formatter: monolog.formatter.json

--- a/config/packages/nelmio_alice.yaml
+++ b/config/packages/nelmio_alice.yaml
@@ -1,0 +1,12 @@
+when@dev: &dev
+    nelmio_alice:
+        functions_blacklist:
+            - 'current'
+            - 'shuffle'
+            - 'date'
+            - 'time'
+            - 'file'
+            - 'md5'
+            - 'sha1'
+
+when@test: *dev

--- a/config/packages/nyholm_psr7.yaml
+++ b/config/packages/nyholm_psr7.yaml
@@ -1,0 +1,11 @@
+services:
+    # Register nyholm/psr7 services for autowiring with PSR-17 (HTTP factories)
+    Psr\Http\Message\RequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@nyholm.psr7.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@nyholm.psr7.psr17_factory'
+
+    nyholm.psr7.psr17_factory:
+        class: Nyholm\Psr7\Factory\Psr17Factory

--- a/config/packages/payum.yaml
+++ b/config/packages/payum.yaml
@@ -1,4 +1,4 @@
-payum:
-    gateways:
-        offline:
-            factory: offline
+#payum:
+#    gateways:
+#        offline:
+#            factory: offline

--- a/config/packages/payum.yaml
+++ b/config/packages/payum.yaml
@@ -1,0 +1,4 @@
+payum:
+    gateways:
+        offline:
+            factory: offline

--- a/config/packages/sylius_resource.yaml
+++ b/config/packages/sylius_resource.yaml
@@ -1,0 +1,15 @@
+# @see https://github.com/Sylius/SyliusResourceBundle/blob/master/docs/index.md
+sylius_resource:
+    # Override default settings
+    #settings:
+
+    # Configure the mapping for your resources
+    mapping:
+        paths:
+            - '%kernel.project_dir%/src/Entity'
+
+    # Configure your resources
+    resources:
+        #app.book:
+            #classes:
+                #model: App\Entity\Book

--- a/config/routes/api_platform.yaml
+++ b/config/routes/api_platform.yaml
@@ -1,0 +1,4 @@
+api_platform:
+    resource: .
+    type: api_platform
+    prefix: /

--- a/config/routes/framework.yaml
+++ b/config/routes/framework.yaml
@@ -1,0 +1,4 @@
+when@dev:
+    _errors:
+        resource: '@FrameworkBundle/Resources/config/routing/errors.xml'
+        prefix: /_error

--- a/config/routes/security.yaml
+++ b/config/routes/security.yaml
@@ -1,0 +1,3 @@
+_security_logout:
+    resource: security.route_loader.logout
+    type: service

--- a/config/routes/sylius_resource.yaml
+++ b/config/routes/sylius_resource.yaml
@@ -1,0 +1,7 @@
+sylius_crud_routes:
+    resource: 'sylius.routing.loader.crud_routes_attributes'
+    type: service
+
+sylius_routes:
+    resource: 'sylius.routing.loader.routes_attributes'
+    type: service

--- a/config/routes/web_profiler.yaml
+++ b/config/routes/web_profiler.yaml
@@ -1,0 +1,8 @@
+when@dev:
+    web_profiler_wdt:
+        resource: '@WebProfilerBundle/Resources/config/routing/wdt.xml'
+        prefix: /_wdt
+
+    web_profiler_profiler:
+        resource: '@WebProfilerBundle/Resources/config/routing/profiler.xml'
+        prefix: /_profiler

--- a/phpspec.yaml.dist
+++ b/phpspec.yaml.dist
@@ -1,6 +1,0 @@
-suites:
-    app:
-        namespace: App
-        psr4_prefix: App
-        src_path: src/
-

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,0 +1,8 @@
+parameters:
+    level: 6
+    paths:
+        - bin/
+        - config/
+        - public/
+        - src/
+        - tests/

--- a/phpstan.dist.neon
+++ b/phpstan.dist.neon
@@ -1,5 +1,5 @@
 parameters:
-    level: 6
+    level: 9
     paths:
         - bin/
         - config/

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,0 @@
-parameters:
-    ignoreErrors:
-        - '/Generator expects value type Symfony\\Component\\HttpKernel\\Bundle\\BundleInterface\, object given\./'

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,29 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/8.5/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php">
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+    colors="true"
+    bootstrap="tests/bootstrap.php"
+>
     <testsuites>
         <testsuite name="Test Suite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+
+    <php>
+        <ini name="error_reporting" value="-1" />
+
+        <!-- ###+ symfony/framework-bundle ### -->
+        <env name="APP_DEBUG" value="0"/>
+        <env name="APP_ENV" value="test"/>
+        <env name="SHELL_VERBOSITY" value="-1" />
+        <!-- ###- symfony/framework-bundle ### -->
+
+        <server name="IS_DOCTRINE_ORM_SUPPORTED" value="true" />
+        <server name="ESCAPE_JSON" value="true" />
+
+        <server name="KERNEL_CLASS" value="App\Kernel" />
+    </php>
 </phpunit>

--- a/src/Entity/Addressing/Address.php
+++ b/src/Entity/Addressing/Address.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Address as BaseAddress;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_address")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_address')]
 class Address extends BaseAddress

--- a/src/Entity/Addressing/Country.php
+++ b/src/Entity/Addressing/Country.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\Country as BaseCountry;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_country")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_country')]
 class Country extends BaseCountry

--- a/src/Entity/Addressing/Province.php
+++ b/src/Entity/Addressing/Province.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\Province as BaseProvince;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_province")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_province')]
 class Province extends BaseProvince

--- a/src/Entity/Addressing/Zone.php
+++ b/src/Entity/Addressing/Zone.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\Zone as BaseZone;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_zone")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_zone')]
 class Zone extends BaseZone

--- a/src/Entity/Addressing/ZoneMember.php
+++ b/src/Entity/Addressing/ZoneMember.php
@@ -7,10 +7,6 @@ namespace App\Entity\Addressing;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Addressing\Model\ZoneMember as BaseZoneMember;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_zone_member")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_zone_member')]
 class ZoneMember extends BaseZoneMember

--- a/src/Entity/Channel/Channel.php
+++ b/src/Entity/Channel/Channel.php
@@ -7,10 +7,6 @@ namespace App\Entity\Channel;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Channel as BaseChannel;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_channel")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_channel')]
 class Channel extends BaseChannel

--- a/src/Entity/Channel/ChannelPriceHistoryConfig.php
+++ b/src/Entity/Channel/ChannelPriceHistoryConfig.php
@@ -7,10 +7,6 @@ namespace App\Entity\Channel;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ChannelPriceHistoryConfig as BaseChannelPriceHistoryConfig;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_channel_price_history_config")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_channel_price_history_config')]
 class ChannelPriceHistoryConfig extends BaseChannelPriceHistoryConfig

--- a/src/Entity/Channel/ChannelPricing.php
+++ b/src/Entity/Channel/ChannelPricing.php
@@ -7,10 +7,6 @@ namespace App\Entity\Channel;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ChannelPricing as BaseChannelPricing;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_channel_pricing")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_channel_pricing')]
 class ChannelPricing extends BaseChannelPricing

--- a/src/Entity/Channel/ChannelPricingLogEntry.php
+++ b/src/Entity/Channel/ChannelPricingLogEntry.php
@@ -7,10 +7,6 @@ namespace App\Entity\Channel;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ChannelPricingLogEntry as BaseChannelPricingLogEntry;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_channel_pricing_log_entry")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_channel_pricing_log_entry')]
 class ChannelPricingLogEntry extends BaseChannelPricingLogEntry

--- a/src/Entity/Currency/Currency.php
+++ b/src/Entity/Currency/Currency.php
@@ -7,10 +7,6 @@ namespace App\Entity\Currency;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Currency\Model\Currency as BaseCurrency;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_currency")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_currency')]
 class Currency extends BaseCurrency

--- a/src/Entity/Currency/ExchangeRate.php
+++ b/src/Entity/Currency/ExchangeRate.php
@@ -7,10 +7,6 @@ namespace App\Entity\Currency;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Currency\Model\ExchangeRate as BaseExchangeRate;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_exchange_rate")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_exchange_rate')]
 class ExchangeRate extends BaseExchangeRate

--- a/src/Entity/Customer/Customer.php
+++ b/src/Entity/Customer/Customer.php
@@ -7,10 +7,6 @@ namespace App\Entity\Customer;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Customer as BaseCustomer;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_customer")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_customer')]
 class Customer extends BaseCustomer

--- a/src/Entity/Customer/CustomerGroup.php
+++ b/src/Entity/Customer/CustomerGroup.php
@@ -7,10 +7,6 @@ namespace App\Entity\Customer;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Customer\Model\CustomerGroup as BaseCustomerGroup;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_customer_group")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_customer_group')]
 class CustomerGroup extends BaseCustomerGroup

--- a/src/Entity/Locale/Locale.php
+++ b/src/Entity/Locale/Locale.php
@@ -7,10 +7,6 @@ namespace App\Entity\Locale;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Locale\Model\Locale as BaseLocale;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_locale")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_locale')]
 class Locale extends BaseLocale

--- a/src/Entity/Order/Adjustment.php
+++ b/src/Entity/Order/Adjustment.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Adjustment as BaseAdjustment;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_adjustment")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_adjustment')]
 class Adjustment extends BaseAdjustment

--- a/src/Entity/Order/Order.php
+++ b/src/Entity/Order/Order.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Order as BaseOrder;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order')]
 class Order extends BaseOrder

--- a/src/Entity/Order/OrderItem.php
+++ b/src/Entity/Order/OrderItem.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderItem as BaseOrderItem;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order_item")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order_item')]
 class OrderItem extends BaseOrderItem

--- a/src/Entity/Order/OrderItemUnit.php
+++ b/src/Entity/Order/OrderItemUnit.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderItemUnit as BaseOrderItemUnit;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order_item_unit")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order_item_unit')]
 class OrderItemUnit extends BaseOrderItemUnit

--- a/src/Entity/Order/OrderSequence.php
+++ b/src/Entity/Order/OrderSequence.php
@@ -7,10 +7,6 @@ namespace App\Entity\Order;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\OrderSequence as BaseOrderSequence;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_order_sequence")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_order_sequence')]
 class OrderSequence extends BaseOrderSequence

--- a/src/Entity/Payment/GatewayConfig.php
+++ b/src/Entity/Payment/GatewayConfig.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Bundle\PayumBundle\Model\GatewayConfig as BaseGatewayConfig;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_gateway_config")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_gateway_config')]
 class GatewayConfig extends BaseGatewayConfig

--- a/src/Entity/Payment/Payment.php
+++ b/src/Entity/Payment/Payment.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Payment as BasePayment;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment')]
 class Payment extends BasePayment

--- a/src/Entity/Payment/PaymentMethod.php
+++ b/src/Entity/Payment/PaymentMethod.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\PaymentMethod as BasePaymentMethod;
 use Sylius\Component\Payment\Model\PaymentMethodTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment_method")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment_method')]
 class PaymentMethod extends BasePaymentMethod

--- a/src/Entity/Payment/PaymentMethodTranslation.php
+++ b/src/Entity/Payment/PaymentMethodTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Payment\Model\PaymentMethodTranslation as BasePaymentMethodTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment_method_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment_method_translation')]
 class PaymentMethodTranslation extends BasePaymentMethodTranslation

--- a/src/Entity/Payment/PaymentSecurityToken.php
+++ b/src/Entity/Payment/PaymentSecurityToken.php
@@ -7,10 +7,6 @@ namespace App\Entity\Payment;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Bundle\PayumBundle\Model\PaymentSecurityToken as BasePaymentSecurityToken;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_payment_security_token")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_payment_security_token')]
 class PaymentSecurityToken extends BasePaymentSecurityToken

--- a/src/Entity/Product/Product.php
+++ b/src/Entity/Product/Product.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Product as BaseProduct;
 use Sylius\Component\Product\Model\ProductTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product')]
 class Product extends BaseProduct

--- a/src/Entity/Product/ProductAssociation.php
+++ b/src/Entity/Product/ProductAssociation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAssociation as BaseProductAssociation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_association")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_association')]
 class ProductAssociation extends BaseProductAssociation

--- a/src/Entity/Product/ProductAssociationType.php
+++ b/src/Entity/Product/ProductAssociationType.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAssociationType as BaseProductAssociationType;
 use Sylius\Component\Product\Model\ProductAssociationTypeTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_association_type")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_association_type')]
 class ProductAssociationType extends BaseProductAssociationType

--- a/src/Entity/Product/ProductAssociationTypeTranslation.php
+++ b/src/Entity/Product/ProductAssociationTypeTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAssociationTypeTranslation as BaseProductAssociationTypeTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_association_type_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_association_type_translation')]
 class ProductAssociationTypeTranslation extends BaseProductAssociationTypeTranslation

--- a/src/Entity/Product/ProductAttribute.php
+++ b/src/Entity/Product/ProductAttribute.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Attribute\Model\AttributeTranslationInterface;
 use Sylius\Component\Product\Model\ProductAttribute as BaseProductAttribute;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_attribute")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_attribute')]
 class ProductAttribute extends BaseProductAttribute

--- a/src/Entity/Product/ProductAttributeTranslation.php
+++ b/src/Entity/Product/ProductAttributeTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAttributeTranslation as BaseProductAttributeTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_attribute_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_attribute_translation')]
 class ProductAttributeTranslation extends BaseProductAttributeTranslation

--- a/src/Entity/Product/ProductAttributeValue.php
+++ b/src/Entity/Product/ProductAttributeValue.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductAttributeValue as BaseProductAttributeValue;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_attribute_value")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_attribute_value')]
 class ProductAttributeValue extends BaseProductAttributeValue

--- a/src/Entity/Product/ProductImage.php
+++ b/src/Entity/Product/ProductImage.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductImage as BaseProductImage;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_image")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_image')]
 class ProductImage extends BaseProductImage

--- a/src/Entity/Product/ProductOption.php
+++ b/src/Entity/Product/ProductOption.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOption as BaseProductOption;
 use Sylius\Component\Product\Model\ProductOptionTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option')]
 class ProductOption extends BaseProductOption

--- a/src/Entity/Product/ProductOptionTranslation.php
+++ b/src/Entity/Product/ProductOptionTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOptionTranslation as BaseProductOptionTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option_translation')]
 class ProductOptionTranslation extends BaseProductOptionTranslation

--- a/src/Entity/Product/ProductOptionValue.php
+++ b/src/Entity/Product/ProductOptionValue.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOptionValue as BaseProductOptionValue;
 use Sylius\Component\Product\Model\ProductOptionValueTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option_value")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option_value')]
 class ProductOptionValue extends BaseProductOptionValue

--- a/src/Entity/Product/ProductOptionValueTranslation.php
+++ b/src/Entity/Product/ProductOptionValueTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductOptionValueTranslation as BaseProductOptionValueTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_option_value_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_option_value_translation')]
 class ProductOptionValueTranslation extends BaseProductOptionValueTranslation

--- a/src/Entity/Product/ProductReview.php
+++ b/src/Entity/Product/ProductReview.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductReview as BaseProductReview;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_review")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_review')]
 class ProductReview extends BaseProductReview

--- a/src/Entity/Product/ProductTaxon.php
+++ b/src/Entity/Product/ProductTaxon.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductTaxon as BaseProductTaxon;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_taxon")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_taxon')]
 class ProductTaxon extends BaseProductTaxon

--- a/src/Entity/Product/ProductTranslation.php
+++ b/src/Entity/Product/ProductTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductTranslation as BaseProductTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_translation')]
 class ProductTranslation extends BaseProductTranslation

--- a/src/Entity/Product/ProductVariant.php
+++ b/src/Entity/Product/ProductVariant.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ProductVariant as BaseProductVariant;
 use Sylius\Component\Product\Model\ProductVariantTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_variant")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_variant')]
 class ProductVariant extends BaseProductVariant

--- a/src/Entity/Product/ProductVariantTranslation.php
+++ b/src/Entity/Product/ProductVariantTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Product;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Product\Model\ProductVariantTranslation as BaseProductVariantTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_product_variant_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_product_variant_translation')]
 class ProductVariantTranslation extends BaseProductVariantTranslation

--- a/src/Entity/Promotion/CatalogPromotion.php
+++ b/src/Entity/Promotion/CatalogPromotion.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\CatalogPromotion as BaseCatalogPromotion;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_catalog_promotion")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_catalog_promotion')]
 class CatalogPromotion extends BaseCatalogPromotion

--- a/src/Entity/Promotion/CatalogPromotionAction.php
+++ b/src/Entity/Promotion/CatalogPromotionAction.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Promotion\Model\CatalogPromotionAction as BaseCatalogPromotionAction;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_catalog_promotion_action")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_catalog_promotion_action')]
 class CatalogPromotionAction extends BaseCatalogPromotionAction

--- a/src/Entity/Promotion/CatalogPromotionScope.php
+++ b/src/Entity/Promotion/CatalogPromotionScope.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\CatalogPromotionScope as BaseCatalogPromotionScope;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_catalog_promotion_scope")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_catalog_promotion_scope')]
 class CatalogPromotionScope extends BaseCatalogPromotionScope

--- a/src/Entity/Promotion/Promotion.php
+++ b/src/Entity/Promotion/Promotion.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Promotion as BasePromotion;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion')]
 class Promotion extends BasePromotion

--- a/src/Entity/Promotion/PromotionAction.php
+++ b/src/Entity/Promotion/PromotionAction.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Promotion\Model\PromotionAction as BasePromotionAction;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion_action")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion_action')]
 class PromotionAction extends BasePromotionAction

--- a/src/Entity/Promotion/PromotionCoupon.php
+++ b/src/Entity/Promotion/PromotionCoupon.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\PromotionCoupon as BasePromotionCoupon;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion_coupon")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion_coupon')]
 class PromotionCoupon extends BasePromotionCoupon

--- a/src/Entity/Promotion/PromotionRule.php
+++ b/src/Entity/Promotion/PromotionRule.php
@@ -7,10 +7,6 @@ namespace App\Entity\Promotion;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Promotion\Model\PromotionRule as BasePromotionRule;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_promotion_rule")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_promotion_rule')]
 class PromotionRule extends BasePromotionRule

--- a/src/Entity/Shipping/Shipment.php
+++ b/src/Entity/Shipping/Shipment.php
@@ -7,10 +7,6 @@ namespace App\Entity\Shipping;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Shipment as BaseShipment;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipment")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipment')]
 class Shipment extends BaseShipment

--- a/src/Entity/Shipping/ShippingCategory.php
+++ b/src/Entity/Shipping/ShippingCategory.php
@@ -7,10 +7,6 @@ namespace App\Entity\Shipping;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Shipping\Model\ShippingCategory as BaseShippingCategory;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipping_category")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipping_category')]
 class ShippingCategory extends BaseShippingCategory

--- a/src/Entity/Shipping/ShippingMethod.php
+++ b/src/Entity/Shipping/ShippingMethod.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ShippingMethod as BaseShippingMethod;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipping_method")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipping_method')]
 class ShippingMethod extends BaseShippingMethod

--- a/src/Entity/Shipping/ShippingMethodTranslation.php
+++ b/src/Entity/Shipping/ShippingMethodTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Shipping;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Shipping\Model\ShippingMethodTranslation as BaseShippingMethodTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shipping_method_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shipping_method_translation')]
 class ShippingMethodTranslation extends BaseShippingMethodTranslation

--- a/src/Entity/Taxation/TaxCategory.php
+++ b/src/Entity/Taxation/TaxCategory.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxation;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Taxation\Model\TaxCategory as BaseTaxCategory;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_tax_category")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_tax_category')]
 class TaxCategory extends BaseTaxCategory

--- a/src/Entity/Taxation/TaxRate.php
+++ b/src/Entity/Taxation/TaxRate.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxation;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\TaxRate as BaseTaxRate;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_tax_rate")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_tax_rate')]
 class TaxRate extends BaseTaxRate

--- a/src/Entity/Taxonomy/Taxon.php
+++ b/src/Entity/Taxonomy/Taxon.php
@@ -8,10 +8,6 @@ use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\Taxon as BaseTaxon;
 use Sylius\Component\Taxonomy\Model\TaxonTranslationInterface;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_taxon")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_taxon')]
 class Taxon extends BaseTaxon

--- a/src/Entity/Taxonomy/TaxonImage.php
+++ b/src/Entity/Taxonomy/TaxonImage.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxonomy;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\TaxonImage as BaseTaxonImage;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_taxon_image")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_taxon_image')]
 class TaxonImage extends BaseTaxonImage

--- a/src/Entity/Taxonomy/TaxonTranslation.php
+++ b/src/Entity/Taxonomy/TaxonTranslation.php
@@ -7,10 +7,6 @@ namespace App\Entity\Taxonomy;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Taxonomy\Model\TaxonTranslation as BaseTaxonTranslation;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_taxon_translation")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_taxon_translation')]
 class TaxonTranslation extends BaseTaxonTranslation

--- a/src/Entity/User/AdminUser.php
+++ b/src/Entity/User/AdminUser.php
@@ -7,10 +7,6 @@ namespace App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\AdminUser as BaseAdminUser;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_admin_user")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_admin_user')]
 class AdminUser extends BaseAdminUser

--- a/src/Entity/User/ShopUser.php
+++ b/src/Entity/User/ShopUser.php
@@ -7,10 +7,6 @@ namespace App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\Core\Model\ShopUser as BaseShopUser;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_shop_user")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_shop_user')]
 class ShopUser extends BaseShopUser

--- a/src/Entity/User/UserOAuth.php
+++ b/src/Entity/User/UserOAuth.php
@@ -7,10 +7,6 @@ namespace App\Entity\User;
 use Doctrine\ORM\Mapping as ORM;
 use Sylius\Component\User\Model\UserOAuth as BaseUserOAuth;
 
-/**
- * @ORM\Entity
- * @ORM\Table(name="sylius_user_oauth")
- */
 #[ORM\Entity]
 #[ORM\Table(name: 'sylius_user_oauth')]
 class UserOAuth extends BaseUserOAuth

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -1,74 +1,13 @@
 <?php
 
-/*
- * This file is part of the Sylius package.
- *
- * (c) Paweł Jędrzejewski
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 declare(strict_types=1);
 
 namespace App;
 
-use PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
-use Symfony\Component\Config\Loader\LoaderInterface;
-use Symfony\Component\Config\Resource\FileResource;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel as BaseKernel;
 
 final class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
-
-    private const CONFIG_EXTS = '.{php,xml,yaml,yml}';
-
-    public function getCacheDir(): string
-    {
-        return $this->getProjectDir() . '/var/cache/' . $this->environment;
-    }
-
-    public function getLogDir(): string
-    {
-        return $this->getProjectDir() . '/var/log';
-    }
-
-    public function registerBundles(): iterable
-    {
-        $contents = require $this->getProjectDir() . '/config/bundles.php';
-        foreach ($contents as $class => $envs) {
-            if (isset($envs['all']) || isset($envs[$this->environment])) {
-                yield new $class();
-            }
-        }
-    }
-
-    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
-    {
-        $container->addResource(new FileResource($this->getProjectDir() . '/config/bundles.php'));
-        $container->setParameter('container.dumper.inline_class_loader', true);
-        $confDir = $this->getProjectDir() . '/config';
-
-        $loader->load($confDir . '/{packages}/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{packages}/' . $this->environment . '/**/*' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{services}' . self::CONFIG_EXTS, 'glob');
-        $loader->load($confDir . '/{services}_' . $this->environment . self::CONFIG_EXTS, 'glob');
-    }
-
-    protected function getContainerBaseClass(): string
-    {
-        if ($this->isTestEnvironment() && class_exists(MockerContainer::class)) {
-            return MockerContainer::class;
-        }
-
-        return parent::getContainerBaseClass();
-    }
-
-    private function isTestEnvironment(): bool
-    {
-        return 0 === strpos($this->getEnvironment(), 'test');
-    }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -476,35 +476,33 @@
             "ref": "6c1ceb662f8997085f739cd089bfbef67f245983"
         }
     },
-    "sylius-labs/association-hydrator": {
-        "version": "v1.1.0"
-    },
-    "sylius-labs/coding-standard": {
-        "version": "v2.0.0"
-    },
     "sylius-labs/doctrine-migrations-extra-bundle": {
-        "version": "v0.1.3"
-    },
-    "sylius-labs/polyfill-symfony-event-dispatcher": {
-        "version": "v1.0.0"
+        "version": "v0.2.2"
     },
     "sylius/fixtures-bundle": {
-        "version": "v1.4.1"
+        "version": "v1.9.0"
     },
     "sylius/grid-bundle": {
-        "version": "v1.5.1"
+        "version": "v1.13.0-ALPHA.3"
     },
     "sylius/mailer-bundle": {
-        "version": "v1.4.4"
-    },
-    "sylius/registry": {
-        "version": "v1.4.1"
+        "version": "v2.1.0-BETA.1"
     },
     "sylius/resource-bundle": {
-        "version": "v1.4.4"
+        "version": "1.12",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.9",
+            "ref": "ee21c1fc90778f4b01c20e72c320cc34f8839c1e"
+        },
+        "files": [
+            "config/packages/sylius_resource.yaml",
+            "config/routes/sylius_resource.yaml"
+        ]
     },
     "sylius/sylius": {
-        "version": "1.13",
+        "version": "2.0",
         "recipe": {
             "repo": "github.com/Sylius/SyliusRecipes",
             "branch": "main",
@@ -513,7 +511,7 @@
         }
     },
     "sylius/theme-bundle": {
-        "version": "v1.4.6"
+        "version": "v2.4.0"
     },
     "sylius/twig-hooks": {
         "version": "v0.3.0"

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,10 +1,4 @@
 {
-    "aeon-php/calendar": {
-        "version": "0.16.4"
-    },
-    "alcohol/iso4217": {
-        "version": "4.0.0"
-    },
     "api-platform/core": {
         "version": "3.4",
         "recipe": {
@@ -20,37 +14,7 @@
         ]
     },
     "babdev/pagerfanta-bundle": {
-        "version": "v2.8.0"
-    },
-    "behat/behat": {
-        "version": "v3.5.0"
-    },
-    "behat/gherkin": {
-        "version": "v4.5.1"
-    },
-    "behat/mink-selenium2-driver": {
-        "version": "v1.3.1"
-    },
-    "behat/transliterator": {
-        "version": "v1.2.0"
-    },
-    "clue/stream-filter": {
-        "version": "v1.4.0"
-    },
-    "coduo/php-matcher": {
-        "version": "3.1.0"
-    },
-    "coduo/php-to-string": {
-        "version": "2.0.1"
-    },
-    "dealerdirect/phpcodesniffer-composer-installer": {
-        "version": "v0.7.1"
-    },
-    "dmore/behat-chrome-extension": {
-        "version": "1.3.0"
-    },
-    "dmore/chrome-mink-driver": {
-        "version": "2.7.0"
+        "version": "v4.4.0"
     },
     "doctrine/annotations": {
         "version": "2.0",
@@ -88,119 +52,53 @@
             "migrations/.gitignore"
         ]
     },
-    "egulias/email-validator": {
-        "version": "2.1.5"
-    },
-    "enshrined/svg-sanitize": {
-        "version": "0.15.4"
-    },
-    "fakerphp/faker": {
-        "version": "v1.12.0"
-    },
-    "fig/link-util": {
-        "version": "1.1.1"
-    },
-    "friends-of-behat/mink": {
-        "version": "v1.8.0"
-    },
-    "friends-of-behat/mink-browserkit-driver": {
-        "version": "v1.4.0"
-    },
-    "friends-of-behat/mink-debug-extension": {
-        "version": "v2.0.1"
-    },
-    "friends-of-behat/mink-extension": {
-        "version": "v2.5.0"
-    },
-    "friends-of-behat/page-object-extension": {
-        "version": "0.1"
-    },
-    "friends-of-behat/suite-settings-extension": {
-        "version": "v1.0.1"
-    },
     "friends-of-behat/symfony-extension": {
-        "version": "v1.2.2"
-    },
-    "friends-of-behat/variadic-extension": {
-        "version": "v1.1.0"
-    },
-    "friendsofphp/proxy-manager-lts": {
-        "version": "v1.0.3"
+        "version": "2.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "2.0",
+            "ref": "1e012e04f573524ca83795cd19df9ea690adb604"
+        },
+        "files": [
+            "behat.yml.dist",
+            "config/services_test.yaml",
+            "features/demo.feature",
+            "tests/Behat/DemoContext.php"
+        ]
     },
     "friendsofsymfony/rest-bundle": {
-        "version": "2.2",
+        "version": "3.7",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
-            "version": "2.2",
-            "ref": "258300d52be6ad59b32a888d5ddafbf9638540ff"
-        }
-    },
-    "gedmo/doctrine-extensions": {
-        "version": "v2.4.36"
-    },
-    "guzzlehttp/guzzle": {
-        "version": "6.3.3"
-    },
-    "guzzlehttp/promises": {
-        "version": "v1.3.1"
-    },
-    "guzzlehttp/psr7": {
-        "version": "1.4.2"
-    },
-    "hamcrest/hamcrest-php": {
-        "version": "v2.0.0"
-    },
-    "imagine/imagine": {
-        "version": "v0.7.1"
-    },
-    "instaclick/php-webdriver": {
-        "version": "1.4.5"
-    },
-    "jms/metadata": {
-        "version": "1.6.0"
-    },
-    "jms/serializer": {
-        "version": "1.13.0"
+            "branch": "main",
+            "version": "3.0",
+            "ref": "3762cc4e4f2d6faabeca5a151b41c8c791bd96e5"
+        },
+        "files": [
+            "config/packages/fos_rest.yaml"
+        ]
     },
     "jms/serializer-bundle": {
-        "version": "2.0",
+        "version": "5.4",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
-            "version": "2.0",
-            "ref": "fe60ce509ef04a3f40da96e3979bc8d9b13b2372"
-        }
-    },
-    "knplabs/gaufrette": {
-        "version": "v0.6.0"
+            "branch": "main",
+            "version": "4.0",
+            "ref": "cc04e10cf7171525b50c18b36004edf64cb478be"
+        },
+        "files": [
+            "config/packages/jms_serializer.yaml"
+        ]
     },
     "knplabs/knp-gaufrette-bundle": {
-        "version": "v0.5.3"
-    },
-    "knplabs/knp-menu": {
-        "version": "2.3.0"
+        "version": "v0.9.0"
     },
     "knplabs/knp-menu-bundle": {
-        "version": "v2.2.1"
-    },
-    "laminas/laminas-code": {
-        "version": "3.4.1"
-    },
-    "laminas/laminas-stdlib": {
-        "version": "3.3.1"
-    },
-    "lchrusciel/api-test-case": {
-        "version": "v3.1.3"
-    },
-    "lcobucci/clock": {
-        "version": "2.0.0"
-    },
-    "lcobucci/jwt": {
-        "version": "3.3.2"
+        "version": "v3.4.2"
     },
     "league/flysystem-bundle": {
-        "version": "2.4",
+        "version": "3.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -212,59 +110,42 @@
             "var/storage/.gitignore"
         ]
     },
-    "league/uri": {
-        "version": "5.3.0"
-    },
-    "league/uri-components": {
-        "version": "1.8.1"
-    },
-    "league/uri-interfaces": {
-        "version": "1.1.0"
-    },
     "lexik/jwt-authentication-bundle": {
-        "version": "2.5",
+        "version": "2.21",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
+            "branch": "main",
             "version": "2.5",
-            "ref": "5b2157bcd5778166a5696e42f552ad36529a07a6"
+            "ref": "e9481b233a11ef7e15fe055a2b21fd3ac1aa2bb7"
         },
         "files": [
             "config/packages/lexik_jwt_authentication.yaml"
         ]
     },
     "liip/imagine-bundle": {
-        "version": "1.8",
+        "version": "2.13",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
+            "branch": "main",
             "version": "1.8",
-            "ref": "7f6676627c1ceeeee204553d24a0545d5f918b7b"
-        }
-    },
-    "marcj/topsort": {
-        "version": "1.1.0"
-    },
-    "mockery/mockery": {
-        "version": "1.1.0"
-    },
-    "monolog/monolog": {
-        "version": "1.23.0"
-    },
-    "myclabs/deep-copy": {
-        "version": "1.8.1"
-    },
-    "namshi/jose": {
-        "version": "7.2.3"
+            "ref": "d1227d002b70d1a1f941d91845fcd7ac7fbfc929"
+        },
+        "files": [
+            "config/packages/liip_imagine.yaml",
+            "config/routes/liip_imagine.yaml"
+        ]
     },
     "nelmio/alice": {
-        "version": "3.2",
+        "version": "3.13",
         "recipe": {
-            "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
-            "version": "3.2",
-            "ref": "5ef2976310e8f9621c1a722a73bfbe115c1559a3"
-        }
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "3.3",
+            "ref": "42b52d2065dc3fde27912d502c18ca1926e35ae2"
+        },
+        "files": [
+            "config/packages/nelmio_alice.yaml"
+        ]
     },
     "nyholm/psr7": {
         "version": "1.8",
@@ -278,12 +159,6 @@
             "config/packages/nyholm_psr7.yaml"
         ]
     },
-    "openlss/lib-array2xml": {
-        "version": "0.0.10"
-    },
-    "pagerfanta/pagerfanta": {
-        "version": "v2.0.1"
-    },
     "payum/payum-bundle": {
         "version": "2.6",
         "recipe": {
@@ -296,152 +171,70 @@
             "config/packages/payum.yaml"
         ]
     },
-    "phar-io/manifest": {
-        "version": "1.0.1"
-    },
-    "phar-io/version": {
-        "version": "1.0.1"
-    },
-    "php-http/httplug": {
-        "version": "v1.1.0"
-    },
-    "php-http/message": {
-        "version": "1.7.0"
-    },
-    "php-http/message-factory": {
-        "version": "v1.0.2"
-    },
-    "php-http/promise": {
-        "version": "v1.0.0"
-    },
-    "phpstan/extension-installer": {
-        "version": "1.0.1"
-    },
-    "phpstan/phpdoc-parser": {
-        "version": "0.3"
-    },
     "phpstan/phpstan": {
-        "version": "0.12.3"
-    },
-    "phpstan/phpstan-doctrine": {
-        "version": "0.11.5"
-    },
-    "phpstan/phpstan-webmozart-assert": {
-        "version": "0.12.8"
-    },
-    "phpunit/php-code-coverage": {
-        "version": "5.3.2"
-    },
-    "phpunit/php-file-iterator": {
-        "version": "1.4.5"
-    },
-    "phpunit/php-text-template": {
-        "version": "1.2.1"
-    },
-    "phpunit/php-timer": {
-        "version": "1.0.9"
-    },
-    "phpunit/phpunit": {
-        "version": "4.7",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.7",
-            "ref": "c276fa48d4713de91eb410289b3b1834acb7e403"
-        }
-    },
-    "polishsymfonycommunity/symfony-mocker-container": {
-        "version": "v1.0.2"
-    },
-    "psr/cache": {
-        "version": "1.0.1"
-    },
-    "psr/container": {
-        "version": "1.0.0"
-    },
-    "psr/event-dispatcher": {
-        "version": "1.0.0"
-    },
-    "psr/http-client": {
-        "version": "1.0.0"
-    },
-    "psr/http-message": {
-        "version": "1.0.1"
-    },
-    "psr/link": {
-        "version": "1.0.0"
-    },
-    "psr/log": {
-        "version": "1.0.2"
-    },
-    "ralouphie/getallheaders": {
-        "version": "2.0.5"
-    },
-    "ramsey/uuid": {
-        "version": "3.8.0"
-    },
-    "sebastian/code-unit-reverse-lookup": {
-        "version": "1.0.1"
-    },
-    "sebastian/comparator": {
-        "version": "2.1.3"
-    },
-    "sebastian/diff": {
-        "version": "2.0.1"
-    },
-    "sebastian/environment": {
-        "version": "3.1.0"
-    },
-    "sebastian/exporter": {
-        "version": "3.1.0"
-    },
-    "sebastian/global-state": {
-        "version": "2.0.0"
-    },
-    "sebastian/object-enumerator": {
-        "version": "3.0.3"
-    },
-    "sebastian/object-reflector": {
-        "version": "1.1.1"
-    },
-    "sebastian/recursion-context": {
-        "version": "3.0.0"
-    },
-    "sebastian/type": {
-        "version": "1.1.3"
-    },
-    "sebastian/version": {
-        "version": "2.0.1"
-    },
-    "slevomat/coding-standard": {
-        "version": "6.4.1"
-    },
-    "sonata-project/block-bundle": {
-        "version": "3.12.1"
-    },
-    "sonata-project/doctrine-extensions": {
-        "version": "1.1.0"
-    },
-    "sonata-project/form-extensions": {
-        "version": "1.0.0"
-    },
-    "sonata-project/twig-extensions": {
-        "version": "1.1.1"
-    },
-    "squizlabs/php_codesniffer": {
-        "version": "3.3.1"
-    },
-    "stella-maris/clock": {
-        "version": "0.1.4"
-    },
-    "stof/doctrine-extensions-bundle": {
-        "version": "1.2",
+        "version": "1.12",
         "recipe": {
             "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
-            "version": "1.2",
-            "ref": "6c1ceb662f8997085f739cd089bfbef67f245983"
+            "branch": "main",
+            "version": "1.0",
+            "ref": "5e490cc197fb6bb1ae22e5abbc531ddc633b6767"
+        },
+        "files": [
+            "phpstan.dist.neon"
+        ]
+    },
+    "phpunit/phpunit": {
+        "version": "10.5",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "9.6",
+            "ref": "7364a21d87e658eb363c5020c072ecfdc12e2326"
+        },
+        "files": [
+            ".env.test",
+            "phpunit.xml.dist",
+            "tests/bootstrap.php"
+        ]
+    },
+    "sonata-project/block-bundle": {
+        "version": "5.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "4.11",
+            "ref": "b4edd2a1e6ac1827202f336cac2771cb529de542"
         }
+    },
+    "sonata-project/form-extensions": {
+        "version": "2.4",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.4",
+            "ref": "9c8a1e8ce2b1f215015ed16652c4ed18eb5867fd"
+        }
+    },
+    "squizlabs/php_codesniffer": {
+        "version": "3.10",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "3.6",
+            "ref": "1019e5c08d4821cb9b77f4891f8e9c31ff20ac6f"
+        }
+    },
+    "stof/doctrine-extensions-bundle": {
+        "version": "1.12",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "1.2",
+            "ref": "e805aba9eff5372e2d149a9ff56566769e22819d"
+        },
+        "files": [
+            "config/packages/stof_doctrine_extensions.yaml"
+        ]
     },
     "sylius-labs/doctrine-migrations-extra-bundle": {
         "version": "v0.2.2"
@@ -738,46 +531,19 @@
             "config/packages/workflow.yaml"
         ]
     },
-    "symplify/easy-coding-standard": {
-        "version": "v4.6.1"
-    },
-    "textalk/websocket": {
-        "version": "1.3.1"
-    },
     "theofidry/alice-data-fixtures": {
-        "version": "1.0",
+        "version": "1.7",
         "recipe": {
-            "repo": "github.com/symfony/recipes-contrib",
-            "branch": "master",
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
             "version": "1.0",
             "ref": "fe5a50faf580eb58f08ada2abe8afbd2d4941e05"
         }
     },
-    "theseer/tokenizer": {
-        "version": "1.1.0"
-    },
     "twig/extra-bundle": {
         "version": "v3.13.0"
     },
-    "twig/intl-extra": {
-        "version": "v2.12.5"
-    },
-    "twig/twig": {
-        "version": "v2.5.0"
-    },
-    "webmozart/assert": {
-        "version": "1.3.0"
-    },
-    "willdurand/jsonp-callback-validator": {
-        "version": "v1.1.0"
-    },
-    "willdurand/negotiation": {
-        "version": "v2.3.1"
-    },
-    "winzou/state-machine": {
-        "version": "0.3.3"
-    },
     "winzou/state-machine-bundle": {
-        "version": "v0.3.1"
+        "version": "v0.6.2"
     }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -317,11 +317,17 @@
     "pagerfanta/pagerfanta": {
         "version": "v2.0.1"
     },
-    "payum/iso4217": {
-        "version": "1.0.1"
-    },
     "payum/payum-bundle": {
-        "version": "2.3.1"
+        "version": "2.6",
+        "recipe": {
+            "repo": "github.com/symfony/recipes-contrib",
+            "branch": "main",
+            "version": "2.4",
+            "ref": "518ac22defa04a8a1d82479ed362e2921487adf0"
+        },
+        "files": [
+            "config/packages/payum.yaml"
+        ]
     },
     "phar-io/manifest": {
         "version": "1.0.1"

--- a/symfony.lock
+++ b/symfony.lock
@@ -53,73 +53,40 @@
         "version": "2.7.0"
     },
     "doctrine/annotations": {
-        "version": "1.0",
+        "version": "2.0",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.0",
-            "ref": "cb4152ebcadbe620ea2261da1a1c5a9b8cea7672"
+            "branch": "main",
+            "version": "1.10",
+            "ref": "64d8583af5ea57b7afa4aba4b159907f3a148b05"
         }
-    },
-    "doctrine/cache": {
-        "version": "v1.8.0"
-    },
-    "doctrine/collections": {
-        "version": "v1.5.0"
-    },
-    "doctrine/common": {
-        "version": "v2.9.0"
-    },
-    "doctrine/data-fixtures": {
-        "version": "v1.3.1"
-    },
-    "doctrine/dbal": {
-        "version": "v2.8.0"
-    },
-    "doctrine/deprecations": {
-        "version": "v0.5.3"
     },
     "doctrine/doctrine-bundle": {
-        "version": "1.6",
+        "version": "2.13",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.6",
-            "ref": "ae205d5114e719deb64d2110f56ef910787d1e04"
-        }
+            "branch": "main",
+            "version": "2.12",
+            "ref": "7266981c201efbbe02ae53c87f8bb378e3f825ae"
+        },
+        "files": [
+            "config/packages/doctrine.yaml",
+            "src/Entity/.gitignore",
+            "src/Repository/.gitignore"
+        ]
     },
     "doctrine/doctrine-migrations-bundle": {
-        "version": "1.2",
+        "version": "3.3",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "1.2",
-            "ref": "c1431086fec31f17fbcfe6d6d7e92059458facc1"
-        }
-    },
-    "doctrine/event-manager": {
-        "version": "v1.0.0"
-    },
-    "doctrine/inflector": {
-        "version": "v1.3.0"
-    },
-    "doctrine/instantiator": {
-        "version": "1.1.0"
-    },
-    "doctrine/lexer": {
-        "version": "v1.0.1"
-    },
-    "doctrine/migrations": {
-        "version": "v1.8.1"
-    },
-    "doctrine/orm": {
-        "version": "v2.6.2"
-    },
-    "doctrine/persistence": {
-        "version": "v1.0.0"
-    },
-    "doctrine/sql-formatter": {
-        "version": "1.1.1"
+            "branch": "main",
+            "version": "3.1",
+            "ref": "1d01ec03c6ecbd67c3375c5478c9a423ae5d6a33"
+        },
+        "files": [
+            "config/packages/doctrine_migrations.yaml",
+            "migrations/.gitignore"
+        ]
     },
     "egulias/email-validator": {
         "version": "2.1.5"

--- a/symfony.lock
+++ b/symfony.lock
@@ -347,24 +347,6 @@
     "php-http/promise": {
         "version": "v1.0.0"
     },
-    "phpdocumentor/reflection-common": {
-        "version": "1.0.1"
-    },
-    "phpdocumentor/reflection-docblock": {
-        "version": "4.3.0"
-    },
-    "phpdocumentor/type-resolver": {
-        "version": "0.4.0"
-    },
-    "phpspec/php-diff": {
-        "version": "v1.1.0"
-    },
-    "phpspec/phpspec": {
-        "version": "4.3.1"
-    },
-    "phpspec/prophecy": {
-        "version": "1.8.0"
-    },
     "phpstan/extension-installer": {
         "version": "1.0.1"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -518,152 +518,96 @@
     "sylius/twig-hooks": {
         "version": "v0.3.0"
     },
-    "symfony/amqp-messenger": {
-        "version": "v5.2.1"
-    },
-    "symfony/asset": {
-        "version": "v4.1.3"
-    },
-    "symfony/browser-kit": {
-        "version": "v4.1.3"
-    },
-    "symfony/cache": {
-        "version": "v4.1.3"
-    },
-    "symfony/cache-contracts": {
-        "version": "v1.1.5"
-    },
-    "symfony/config": {
-        "version": "v4.1.3"
-    },
     "symfony/console": {
-        "version": "3.3",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "e3868d2f4a5104f19f844fe551099a00c6562527"
-        }
-    },
-    "symfony/css-selector": {
-        "version": "v4.1.3"
+            "branch": "main",
+            "version": "5.3",
+            "ref": "1781ff40d8a17d87cf53f8d4cf0c8346ed2bb461"
+        },
+        "files": [
+            "bin/console"
+        ]
     },
     "symfony/debug-bundle": {
-        "version": "4.1",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.1",
-            "ref": "f8863cbad2f2e58c4b65fa1eac892ab189971bea"
-        }
-    },
-    "symfony/dependency-injection": {
-        "version": "v4.1.3"
-    },
-    "symfony/deprecation-contracts": {
-        "version": "v2.2.0"
-    },
-    "symfony/doctrine-bridge": {
-        "version": "v4.1.3"
-    },
-    "symfony/doctrine-messenger": {
-        "version": "v5.2.1"
-    },
-    "symfony/dom-crawler": {
-        "version": "v4.1.3"
-    },
-    "symfony/dotenv": {
-        "version": "v4.1.3"
-    },
-    "symfony/error-handler": {
-        "version": "v4.4.18"
-    },
-    "symfony/event-dispatcher": {
-        "version": "v4.1.3"
-    },
-    "symfony/event-dispatcher-contracts": {
-        "version": "v1.1.5"
-    },
-    "symfony/expression-language": {
-        "version": "v4.1.3"
-    },
-    "symfony/filesystem": {
-        "version": "v4.1.3"
-    },
-    "symfony/finder": {
-        "version": "v4.1.3"
+            "branch": "main",
+            "version": "5.3",
+            "ref": "5aa8aa48234c8eb6dbdd7b3cd5d791485d2cec4b"
+        },
+        "files": [
+            "config/packages/debug.yaml"
+        ]
     },
     "symfony/flex": {
-        "version": "1.0",
+        "version": "2.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
+            "branch": "main",
             "version": "1.0",
-            "ref": "e921bdbfe20cdefa3b82f379d1cd36df1bc8d115"
-        }
-    },
-    "symfony/form": {
-        "version": "v4.1.3"
+            "ref": "146251ae39e06a95be0fe3d13c807bcf3938b172"
+        },
+        "files": [
+            ".env"
+        ]
     },
     "symfony/framework-bundle": {
-        "version": "3.3",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "87c585d24de9f43bca80ebcfd5cf5cb39445d95f"
-        }
-    },
-    "symfony/http-foundation": {
-        "version": "v4.1.3"
-    },
-    "symfony/http-kernel": {
-        "version": "v4.1.3"
-    },
-    "symfony/intl": {
-        "version": "v4.1.3"
+            "branch": "main",
+            "version": "7.0",
+            "ref": "6356c19b9ae08e7763e4ba2d9ae63043efc75db5"
+        },
+        "files": [
+            "config/packages/cache.yaml",
+            "config/packages/framework.yaml",
+            "config/preload.php",
+            "config/routes/framework.yaml",
+            "config/services.yaml",
+            "public/index.php",
+            "src/Controller/.gitignore",
+            "src/Kernel.php"
+        ]
     },
     "symfony/mailer": {
-        "version": "5.4",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "4.3",
-            "ref": "97a61eabb351d7f6cb7702039bcfe07fe9d7e03c"
+            "ref": "df66ee1f226c46f01e85c29c2f7acce0596ba35a"
         },
         "files": [
             "config/packages/mailer.yaml"
         ]
     },
     "symfony/messenger": {
-        "version": "4.3",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.3",
-            "ref": "8a2675c061737658bed85102e9241c752620e575"
+            "branch": "main",
+            "version": "6.0",
+            "ref": "ba1ac4e919baba5644d31b57a3284d6ba12d52ee"
         },
         "files": [
             "config/packages/messenger.yaml"
         ]
     },
-    "symfony/mime": {
-        "version": "v4.3.1"
-    },
-    "symfony/monolog-bridge": {
-        "version": "v4.1.3"
-    },
     "symfony/monolog-bundle": {
-        "version": "3.1",
+        "version": "3.10",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.1",
-            "ref": "18ebf5a940573a20de06f9c4060101eeb438cf3d"
-        }
-    },
-    "symfony/options-resolver": {
-        "version": "v4.1.3"
+            "branch": "main",
+            "version": "3.7",
+            "ref": "aff23899c4440dd995907613c1dd709b6f59503f"
+        },
+        "files": [
+            "config/packages/monolog.yaml"
+        ]
     },
     "symfony/panther": {
         "version": "2.1",
@@ -671,116 +615,77 @@
             "repo": "github.com/symfony/recipes",
             "branch": "main",
             "version": "1.0",
-            "ref": "292a3236e81f55b545b09b9954ab097248972ab3"
+            "ref": "673836afb0eac2b0ec36c44f2ff0379e5a4b2177"
         }
-    },
-    "symfony/password-hasher": {
-        "version": "v5.3.2"
-    },
-    "symfony/polyfill-mbstring": {
-        "version": "v1.9.0"
-    },
-    "symfony/polyfill-php81": {
-        "version": "v1.23.0"
-    },
-    "symfony/process": {
-        "version": "v4.1.3"
-    },
-    "symfony/property-access": {
-        "version": "v4.1.3"
-    },
-    "symfony/property-info": {
-        "version": "v5.1.2"
-    },
-    "symfony/proxy-manager-bridge": {
-        "version": "v4.1.3"
-    },
-    "symfony/redis-messenger": {
-        "version": "v5.2.1"
     },
     "symfony/routing": {
-        "version": "4.0",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.0",
-            "ref": "cda8b550123383d25827705d05a42acf6819fe4e"
-        }
-    },
-    "symfony/security-bundle": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "f8a63faa0d9521526499c0a8f403c9964ecb0527"
-        }
-    },
-    "symfony/security-core": {
-        "version": "v4.4.18"
-    },
-    "symfony/security-csrf": {
-        "version": "v5.2.1"
-    },
-    "symfony/security-guard": {
-        "version": "v4.4.18"
-    },
-    "symfony/security-http": {
-        "version": "v4.4.18"
-    },
-    "symfony/serializer": {
-        "version": "v5.1.2"
-    },
-    "symfony/service-contracts": {
-        "version": "v1.1.6"
-    },
-    "symfony/stimulus-bundle": {
-        "version": "2.19",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
-            "version": "2.8",
-            "ref": "9e33a8a3794b603fb4be6c04ee5ecab901ce549e"
-        }
+            "version": "7.0",
+            "ref": "21b72649d5622d8f7da329ffb5afb232a023619d"
+        },
+        "files": [
+            "config/packages/routing.yaml",
+            "config/routes.yaml"
+        ]
     },
-    "symfony/stopwatch": {
-        "version": "v4.1.3"
+    "symfony/security-bundle": {
+        "version": "7.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.4",
+            "ref": "2ae08430db28c8eb4476605894296c82a642028f"
+        },
+        "files": [
+            "config/packages/security.yaml",
+            "config/routes/security.yaml"
+        ]
     },
-    "symfony/string": {
-        "version": "v5.2.1"
-    },
-    "symfony/templating": {
-        "version": "v4.1.3"
-    },
-    "symfony/thanks": {
-        "version": "v1.0.8"
+    "symfony/stimulus-bundle": {
+        "version": "2.20",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.13",
+            "ref": "6acd9ff4f7fd5626d2962109bd4ebab351d43c43"
+        },
+        "files": [
+            "assets/bootstrap.js",
+            "assets/controllers.json",
+            "assets/controllers/hello_controller.js"
+        ]
     },
     "symfony/translation": {
-        "version": "3.3",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "6bcd6c570c017ea6ae5a7a6a027c929fd3542cd8"
-        }
-    },
-    "symfony/translation-contracts": {
-        "version": "v1.1.6"
-    },
-    "symfony/twig-bridge": {
-        "version": "v4.1.3"
+            "branch": "main",
+            "version": "6.3",
+            "ref": "e28e27f53663cc34f0be2837aba18e3a1bef8e7b"
+        },
+        "files": [
+            "config/packages/translation.yaml",
+            "translations/.gitignore"
+        ]
     },
     "symfony/twig-bundle": {
-        "version": "3.3",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "f75ac166398e107796ca94cc57fa1edaa06ec47f"
-        }
+            "branch": "main",
+            "version": "6.4",
+            "ref": "cab5fd2a13a45c266d45a7d9337e28dee6272877"
+        },
+        "files": [
+            "config/packages/twig.yaml",
+            "templates/base.html.twig"
+        ]
     },
     "symfony/ux-autocomplete": {
-        "version": "2.19",
+        "version": "2.20",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -792,7 +697,7 @@
         ]
     },
     "symfony/ux-live-component": {
-        "version": "2.19",
+        "version": "2.20",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -804,7 +709,7 @@
         ]
     },
     "symfony/ux-twig-component": {
-        "version": "2.19",
+        "version": "2.20",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -816,45 +721,40 @@
         ]
     },
     "symfony/validator": {
-        "version": "4.1",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "4.1",
-            "ref": "0cdc982334f45d554957a6167e030482795bf9d7"
-        }
-    },
-    "symfony/var-dumper": {
-        "version": "v4.1.3"
-    },
-    "symfony/var-exporter": {
-        "version": "v4.2.1"
-    },
-    "symfony/web-link": {
-        "version": "v5.1.2"
-    },
-    "symfony/web-profiler-bundle": {
-        "version": "3.3",
-        "recipe": {
-            "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "3.3",
-            "ref": "6bdfa1a95f6b2e677ab985cd1af2eae35d62e0f6"
-        }
-    },
-    "symfony/webpack-encore-bundle": {
-        "version": "1.15",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
-            "version": "1.10",
-            "ref": "51fec8b86251b9bfc126ebc1827c9a02fa81ee81"
+            "version": "7.0",
+            "ref": "8c1c4e28d26a124b0bb273f537ca8ce443472bfd"
+        },
+        "files": [
+            "config/packages/validator.yaml"
+        ]
+    },
+    "symfony/web-profiler-bundle": {
+        "version": "7.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "6.1",
+            "ref": "e42b3f0177df239add25373083a564e5ead4e13a"
+        },
+        "files": [
+            "config/packages/web_profiler.yaml",
+            "config/routes/web_profiler.yaml"
+        ]
+    },
+    "symfony/webpack-encore-bundle": {
+        "version": "2.1",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.0",
+            "ref": "082d754b3bd54b3fc669f278f1eea955cfd23cf5"
         },
         "files": [
             "assets/app.js",
-            "assets/bootstrap.js",
-            "assets/controllers.json",
-            "assets/controllers/hello_controller.js",
             "assets/styles/app.css",
             "config/packages/webpack_encore.yaml",
             "package.json",
@@ -862,7 +762,7 @@
         ]
     },
     "symfony/workflow": {
-        "version": "6.4",
+        "version": "7.1",
         "recipe": {
             "repo": "github.com/symfony/recipes",
             "branch": "main",
@@ -872,9 +772,6 @@
         "files": [
             "config/packages/workflow.yaml"
         ]
-    },
-    "symfony/yaml": {
-        "version": "v4.1.3"
     },
     "symplify/easy-coding-standard": {
         "version": "v4.6.1"

--- a/symfony.lock
+++ b/symfony.lock
@@ -6,17 +6,17 @@
         "version": "4.0.0"
     },
     "api-platform/core": {
-        "version": "2.5",
+        "version": "3.4",
         "recipe": {
             "repo": "github.com/symfony/recipes",
-            "branch": "master",
-            "version": "2.5",
-            "ref": "a93061567140e386f107be75340ac2aee3f86cbf"
+            "branch": "main",
+            "version": "3.3",
+            "ref": "74b45ac570c57eb1fbe56c984091a9ff87e18bab"
         },
         "files": [
             "config/packages/api_platform.yaml",
             "config/routes/api_platform.yaml",
-            "src/Entity/.gitignore"
+            "src/ApiResource/.gitignore"
         ]
     },
     "babdev/pagerfanta-bundle": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+use Symfony\Component\Dotenv\Dotenv;
+
+require dirname(__DIR__).'/vendor/autoload.php';
+
+if (file_exists(dirname(__DIR__).'/config/bootstrap.php')) {
+    require dirname(__DIR__).'/config/bootstrap.php';
+} elseif (method_exists(Dotenv::class, 'bootEnv')) {
+    (new Dotenv())->bootEnv(dirname(__DIR__).'/.env');
+}


### PR DESCRIPTION
This PR refreshes the project structure by upgrading Symfony recipes, committing default bundle configurations, and removing obsolete code.

Key changes:
	1.	Dropped PHPSpec
	2.	Adjusted PHPStan and PHPUnit configurations
	3.	Updated third-party recipe configuration files to align with Sylius
	4.	Removed annotations
	5.	Moved the migrations directory

An example migration:
<img width="948" alt="image" src="https://github.com/user-attachments/assets/8b279028-acba-412b-9cad-73ed544b0206">
