### PR TITLE
Fix Platform.sh template

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -84,6 +84,10 @@ dependencies:
     php:
         composer/composer: '^2'
 
+runtime:
+    extensions:
+        - sodium
+
 crons:
     sylius-cancel-unpaid-orders:
         spec: "0 2 * * *"


### PR DESCRIPTION
Missing `sodium` PHP extension results in an inability to build the the project on [platform.sh](https://platform.sh/)

```
      Found a `composer.json`, installing dependencies.
        W: Installing dependencies from lock file (including require-dev)
        W: Verifying lock file contents can be installed on current platform.
        W: Your lock file does not contain a compatible set of packages. Please run composer update.
        W: 
        W:   Problem 1
        W:     - lcobucci/jwt is locked to version 4.3.0 and an update of this package was not requested.
        W:     - lcobucci/jwt 4.3.0 requires ext-sodium * -> it is missing from your system. Install or enable PHP's sodium extension.
        W:   Problem 2
        W:     - lcobucci/jwt 4.3.0 requires ext-sodium * -> it is missing from your system. Install or enable PHP's sodium extension.
        W:     - lexik/jwt-authentication-bundle v2.17.0 requires lcobucci/jwt ^3.4|^4.0 -> satisfiable by lcobucci/jwt[4.3.0].
        W:     - lexik/jwt-authentication-bundle is locked to version v2.17.0 and an update of this package was not requested.
        W: 
        W: To enable extensions, verify that they are enabled in your .ini files:
        W:     - /etc/php/8.3/cli/php.ini
        W: You can also run `php --ini` in a terminal to see which files are used by PHP in CLI mode.
        W: Alternatively, you can run Composer with `--ignore-platform-req=ext-sodium` to temporarily ignore these required extensions.
      
      E: Error building project: `composer` could not be run.

    E: Error: Unable to build application, aborting.
```

This will fix it resulting in a successful build.