### PR TITLE
Reflect Sylius 2.0 Codebase Changes - Continuation

### DIFF
--- a/config/bundles.php
+++ b/config/bundles.php
@@ -29,7 +29,6 @@ return [
     Sylius\Bundle\CoreBundle\SyliusCoreBundle::class => ['all' => true],
     Sylius\Bundle\ResourceBundle\SyliusResourceBundle::class => ['all' => true],
     Sylius\Bundle\GridBundle\SyliusGridBundle::class => ['all' => true],
-    Sonata\BlockBundle\SonataBlockBundle::class => ['all' => true],
     Knp\Bundle\GaufretteBundle\KnpGaufretteBundle::class => ['all' => true],
     Knp\Bundle\MenuBundle\KnpMenuBundle::class => ['all' => true],
     Liip\ImagineBundle\LiipImagineBundle::class => ['all' => true],

--- a/config/bundles.php
+++ b/config/bundles.php
@@ -59,4 +59,5 @@ return [
     Symfony\UX\Autocomplete\AutocompleteBundle::class => ['all' => true],
     Symfony\UX\StimulusBundle\StimulusBundle::class => ['all' => true],
     Sylius\TwigExtra\Symfony\SyliusTwigExtraBundle::class => ['all' => true],
+    Symfony\UX\Icons\UXIconsBundle::class => ['all' => true],
 ];

--- a/config/packages/http_discovery.yaml
+++ b/config/packages/http_discovery.yaml
@@ -1,0 +1,10 @@
+services:
+    Psr\Http\Message\RequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ResponseFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\ServerRequestFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\StreamFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UploadedFileFactoryInterface: '@http_discovery.psr17_factory'
+    Psr\Http\Message\UriFactoryInterface: '@http_discovery.psr17_factory'
+
+    http_discovery.psr17_factory:
+        class: Http\Discovery\Psr17Factory

--- a/config/packages/test/sylius_uploader.yaml
+++ b/config/packages/test/sylius_uploader.yaml
@@ -1,3 +1,3 @@
 services:
-    Sylius\Component\Core\Generator\ImagePathGeneratorInterface:
+    sylius.generator.image_path:
         class: Sylius\Behat\Service\Generator\UploadedImagePathGenerator

--- a/config/routes/sylius_shop.yaml
+++ b/config/routes/sylius_shop.yaml
@@ -14,7 +14,7 @@ sylius_shop_default_locale:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius.controller.shop.locale_switch::switchAction
+        _controller: sylius_shop.controller.shop.locale_switch::switchAction
 
 # see https://web.dev/change-password-url/
 sylius_shop_request_password_reset_token_redirect:

--- a/config/routes/sylius_shop.yaml
+++ b/config/routes/sylius_shop.yaml
@@ -14,7 +14,7 @@ sylius_shop_default_locale:
     path: /
     methods: [GET]
     defaults:
-        _controller: sylius_shop.controller.shop.locale_switch::switchAction
+        _controller: sylius_shop.controller.locale_switch::switchAction
 
 # see https://web.dev/change-password-url/
 sylius_shop_request_password_reset_token_redirect:

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@babel/plugin-proposal-object-rest-spread": "^7.18.9",
     "@hotwired/stimulus": "^3.0.0",
     "@symfony/stimulus-bridge": "^3.2.0",
+    "@symfony/webpack-encore": "^5.0.1",
     "sass": "^1.54.8",
     "sass-loader": "^13.0.0",
     "tom-select": "^2.2.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@symfony/stimulus-bridge": "^3.2.0",
     "@symfony/webpack-encore": "^5.0.1",
     "sass": "^1.54.8",
-    "sass-loader": "^13.0.0",
+    "sass-loader": "^16.0.2",
     "tom-select": "^2.2.2"
   }
 }

--- a/symfony.lock
+++ b/symfony.lock
@@ -171,6 +171,18 @@
             "config/packages/payum.yaml"
         ]
     },
+    "php-http/discovery": {
+        "version": "1.20",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "1.18",
+            "ref": "f45b5dd173a27873ab19f5e3180b2f661c21de02"
+        },
+        "files": [
+            "config/packages/http_discovery.yaml"
+        ]
+    },
     "phpstan/phpstan": {
         "version": "1.12",
         "recipe": {

--- a/symfony.lock
+++ b/symfony.lock
@@ -472,6 +472,18 @@
             "config/routes/ux_autocomplete.yaml"
         ]
     },
+    "symfony/ux-icons": {
+        "version": "2.21",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "main",
+            "version": "2.17",
+            "ref": "803a3bbd5893f9584969ab8670290cdfb6a0a5b5"
+        },
+        "files": [
+            "assets/icons/symfony.svg"
+        ]
+    },
     "symfony/ux-live-component": {
         "version": "2.20",
         "recipe": {


### PR DESCRIPTION
Continuation of https://github.com/Sylius/Sylius-Standard/pull/1036

Fixes:
1. Sylius service ID changes
<img width="1068" alt="image" src="https://github.com/user-attachments/assets/41a3a0f7-693d-4365-a118-b532d1106869">
2. Behat `sylius.generator.image_path` service ID correct override
<img width="1008" alt="image" src="https://github.com/user-attachments/assets/bc3576a8-0073-4c0d-b312-25b723de37fb">
3. Proper assets build
<img width="957" alt="image" src="https://github.com/user-attachments/assets/29fdda5f-65e1-4bef-b048-59b2e58f342c">
4. Sylius registered bundles changes