### PR TITLE
Remove unneed excludes from services autowiring

### DIFF
--- a/config/services.yaml
+++ b/config/services.yaml
@@ -21,7 +21,7 @@ services:
     # this creates a service per class whose id is the fully-qualified class name
     App\:
         resource: '../src/*'
-        exclude: '../src/{Entity,Migrations,Tests,Kernel.php}'
+        exclude: '../src/{Entity,Kernel.php}'
 
     # Controllers are imported separately to make sure services can be injected
     # as action arguments even if you don't extend any base controller class


### PR DESCRIPTION
As migrations went up to `migrations` folder and tests were never meant to be in src folder, let's remove them from exclude clause as well