### PR TITLE
Use existing test.key instead of dev.key for payment encryption

### DIFF
--- a/.env
+++ b/.env
@@ -38,4 +38,4 @@ JWT_PASSPHRASE=e7c5fca1060bdf6ad23c33e4c236081f
 MAILER_DSN=null://null
 ###< symfony/mailer ###
 
-SYLIUS_PAYMENT_ENCRYPTION_KEY_PATH=%kernel.project_dir%/config/encryption/dev.key
+SYLIUS_PAYMENT_ENCRYPTION_KEY_PATH=%kernel.project_dir%/config/encryption/test.key


### PR DESCRIPTION
The `test.key` file already exists in the repository and is suitable for development/testing purposes. Using it eliminates the need for developers to generate a `dev.key` file locally, making the setup simpler and cleaner.
