### PR TITLE
Remove `APP_DEBUG` from `compose.override.dist.yml`

### DIFF
--- a/compose.override.dist.yml
+++ b/compose.override.dist.yml
@@ -7,7 +7,6 @@ services:
                 condition: service_healthy
         environment:
             # You can move these environment variables to your .env.local file
-            APP_DEBUG: 0
             APP_ENV: ${ENV:-prod}
             APP_SECRET: EDITME
             DATABASE_URL: "mysql://root@mysql/sylius_%kernel.environment%"


### PR DESCRIPTION
This env variable can be set via `.env` and `.env.*`, and is already being set that way. Specifying it here not only makes it redundant, but also disables the logic of this value being dynamically assigned depending on `APP_ENV`