### PR TITLE
fix: make init error with docker check v1.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,6 @@ node-watch:
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm -i nodejs "npm run watch"
 
 docker-compose-check:
-	@which $(DOCKER_COMPOSE) > /dev/null || (echo "Please install docker compose binary" && exit 1)
+	@$(DOCKER_COMPOSE) version >/dev/null 2>&1 || (echo "Please install docker compose binary or set DOCKER_COMPOSE=\"docker-compose\" for legacy binary" && exit 1)
 	@echo "You are using \"$(DOCKER_COMPOSE)\" binary"
 	@echo "Current version is \"$$($(DOCKER_COMPOSE) version)\""


### PR DESCRIPTION
FIx issue when run make init v1.14

make[1]: *** [docker-compose-check] Error 1

v2: https://github.com/Sylius/Sylius-Standard/pull/1072