### PR TITLE
fix (docker): npm dependencies warning Unsupported engine

### DIFF
--- a/compose.override.dist.yml
+++ b/compose.override.dist.yml
@@ -49,7 +49,7 @@ services:
         ports:
             - "80:80"
     nodejs:
-        image: node:${NODE_VERSION:-18}-alpine
+        image: node:${NODE_VERSION:-20}-alpine
         user: ${DOCKER_USER:-1000:1000}
         working_dir: /srv/sylius
         entrypoint: [ "/bin/sh","-c" ]


### PR DESCRIPTION
**Sylius version affected: 2.0**

**Steps to reproduce**

- `git clone https://github.com/Sylius/Sylius-Standard.git`
- `make init`
- Waiting for node dependencies to be installed

When running `npm install` a warning appears:
`package: '@sylius-ui/admin@2.0.0' required: { node: '^20 || ^22' }. But docker runs 'v18.12.1'`

![Screenshot from 2024-11-15 18-08-45](https://github.com/user-attachments/assets/9f3849d8-68f1-441f-a4f4-b3602550abb0)
