### PR TITLE
Fix docker nodejs permission in MacOS

### DIFF
--- a/compose.override.dist.yml
+++ b/compose.override.dist.yml
@@ -49,10 +49,12 @@ services:
         ports:
             - "80:80"
     nodejs:
-        image: node:${NODE_VERSION:-20}-alpine
+        build:
+            context: docker/nodejs
+            args:
+                - NODE_VERSION:${NODE_VERSION:-20}
         user: ${DOCKER_USER:-1000:1000}
         working_dir: /srv/sylius
-        entrypoint: [ "/bin/sh","-c" ]
         command:
             - |
                 npm install

--- a/docker/nodejs/Dockerfile
+++ b/docker/nodejs/Dockerfile
@@ -1,0 +1,27 @@
+ARG NODE_VERSION=20
+ARG FIXUID_VERSION=0.6.0
+
+FROM node:${NODE_VERSION}-alpine
+
+ARG FIXUID_VERSION
+
+RUN apk --no-cache add curl
+
+COPY docker-entrypoint /usr/local/bin/
+
+RUN USER=node && \
+    GROUP=node && \
+    if [[ "$(uname -m)" = "aarch64" ]] ; \
+      then \
+        curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-arm64.tar.gz | tar -C /usr/local/bin -xzf - ;\
+      else \
+        curl -SsL https://github.com/boxboat/fixuid/releases/download/v${FIXUID_VERSION}/fixuid-${FIXUID_VERSION}-linux-amd64.tar.gz | tar -C /usr/local/bin -xzf - ;\
+    fi; \
+    chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: $USER\ngroup: $GROUP\n" > /etc/fixuid/config.yml
+
+USER node:node
+
+ENTRYPOINT ["docker-entrypoint"]

--- a/docker/nodejs/docker-entrypoint
+++ b/docker/nodejs/docker-entrypoint
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -e
+
+eval $( fixuid )
+
+if [ $# -eq 1 ]; then
+    # Use a subshell to execute the potentially multiline command
+    exec /bin/sh -c "$1"
+else
+    exec "$@"
+fi


### PR DESCRIPTION
There is an error when run `make init` (v2.0) in MacOS with nodejs container