### PR TITLE
feat: Enable Composer's 'bump-after-update' option by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -77,7 +77,8 @@
             "symfony/flex": true,
             "symfony/runtime": true,
             "symfony/thanks": false
-        }
+        },
+        "bump-after-update": true
     },
     "extra": {
         "branch-alias": {


### PR DESCRIPTION
This PR enables the `config.bump-after-update` Composer option by default.

**Usefulness:**
When enabled, `composer update` will automatically update the version constraints in `composer.json` to match the newly installed versions (if compatible). This keeps the `composer.json` file more closely aligned with the actual project state (`composer.lock`), making dependency requirements more explicit over time.

**Impact on End User:**
Developers using `sylius-standard` will notice their `composer.json` being automatically updated after running `composer update`. They will need to commit these changes along with the `composer.lock` file. This promotes better dependency hygiene with minimal workflow change.