### PR TITLE
Updates .platform.app.yaml to include webp

### DIFF
--- a/.platform.app.yaml
+++ b/.platform.app.yaml
@@ -65,7 +65,7 @@ web:
             passthru: true
             allow: false
             rules:
-                '\.(jpe?g|png|gif|svgz?)$':
+                '\.(jpe?g|png|gif|svgz?|webp)$':
                     allow: true
 
 variables:


### PR DESCRIPTION
## Description of change
adds webp to list of allowed extensions for `/media/cache` location

## Additional Information
Recently tried to deploy Sylius on Platform.sh and many of the images on the home page were broken. 

![image](https://github.com/user-attachments/assets/8d67fe7c-8079-470d-8ce5-cfcec99d6600)

Further investigation revealed [the rule](https://github.com/Sylius/Sylius-Standard/blob/2.0/.platform.app.yaml#L68) for the `/media/cache` location only allowed for `jpe?g|png|gif|svgz` thereby blocking requests for webp. 