### PR TITLE
Fix twig mapping

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,5 +1,7 @@
 twig:
-    paths: ['%kernel.project_dir%/templates']
+    default_path: '%kernel.project_dir%/templates'
+    paths:
+        '%kernel.project_dir%/templates': App
     debug: '%kernel.debug%'
     strict_variables: '%kernel.debug%'
 


### PR DESCRIPTION
```
sylius_twig_hooks:
    hooks:
        'sylius_shop.account.profile_update.update.content.main.form':
            phone_number:
                enabled: false
            secondary_phone_number:
                template: '@App/account/profile_update/update/content/main/form/secondary_phone_number.html.twig'
                priority: 600

```

To support binding `@App` to the `templates` directory,
this change also resolves the corresponding error:
<img width="1041" alt="image" src="https://github.com/user-attachments/assets/b8c6ef42-011e-401c-9bf0-394a86759c2b" />
