### PR TITLE
Fix nginx container start

### DIFF
--- a/compose.override.dist.yml
+++ b/compose.override.dist.yml
@@ -43,6 +43,9 @@ services:
         ports:
             - "3306:3306"
     nginx:
+        depends_on:
+            php:
+                condition: service_started
         volumes:
             - ./public:/srv/sylius/public:ro
             # if you develop on Linux, you may use a bind-mounted host directory instead


### PR DESCRIPTION
Fixes https://github.com/Sylius/Sylius-Standard/issues/1116 It makes nginx container dependant on started php container