### PR TITLE
Add Sylius UI component namespace to `twig_component` defaults configuration

### DIFF
--- a/config/packages/twig_component.yaml
+++ b/config/packages/twig_component.yaml
@@ -2,4 +2,5 @@ twig_component:
     anonymous_template_directory: 'components/'
     defaults:
         # Namespace & directory for components
+        Sylius\Bundle\UiBundle\Twig\Component\: '@SyliusUiBundle/Twig/Component/'
         App\Twig\Components\: 'components/'


### PR DESCRIPTION
This PR resolves the issue that occurs when a new component is registered within the end application:

<img width="1650" alt="image" src="https://github.com/user-attachments/assets/62c0dccd-6988-4847-ab06-b9429faeff86" />
