### PR TITLE
Add Reorder Functionality to Customer Order Items

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,16 @@ clean:
 php-shell:
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) exec php sh
 
+sf: ## List all Symfony commands or pass the parameter "c=" to run a given command, example: make sf c=about
+	@$(eval c ?=)
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) exec php bin/console $(c)
+
+cc: c=c:c ## Clear the cache
+cc: sf
+
+run-tests:
+	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm php vendor/bin/phpunit --colors=always --testdox
+
 node-shell:
 	@ENV=$(ENV) DOCKER_USER=$(DOCKER_USER) $(DOCKER_COMPOSE) run --rm -i nodejs sh
 

--- a/config/packages/sylius_twig_hooks.yaml
+++ b/config/packages/sylius_twig_hooks.yaml
@@ -1,0 +1,11 @@
+sylius_twig_hooks:
+    hooks:
+        sylius_shop.shared.order.show.summary.table.header:
+            actions_header:
+                template: 'shop/order/show/summary/table/header/actions.html.twig'
+                priority: 10
+
+        sylius_shop.shared.order.show.summary.table.body:
+            actions_button:
+                template: 'shop/order/show/summary/table/body/actions.html.twig'
+                priority: 10

--- a/src/Controller/Shop/ReorderController.php
+++ b/src/Controller/Shop/ReorderController.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Controller\Shop;
+
+use App\Exception\ReorderException;
+use App\Service\Order\OrderItemReorderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Routing\Attribute\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+final class ReorderController extends AbstractController
+{
+    public function __construct(
+        private readonly OrderItemReorderInterface $reorderService,
+    )
+    {
+    }
+
+    #[Route('/shop/reorder/{id}', name: 'shop_reorder_item', methods: ['POST'])]
+    #[IsGranted('IS_AUTHENTICATED_FULLY')]
+    public function reorder(Request $request, OrderItemInterface $orderItem): RedirectResponse
+    {
+        $this->checkCsrfToken($request, $orderItem->getId());
+
+        try {
+            $this->reorderService->reorder($orderItem);
+            $this->addFlash('success', 'Item added to cart successfully.');
+        } catch (ReorderException $e) {
+            $this->addFlash('error', $e->getMessage());
+        }
+
+        return $this->redirectToRoute('sylius_shop_cart_summary');
+    }
+
+    private function checkCsrfToken(Request $request, $orderId): void
+    {
+        if (!$this->isCsrfTokenValid('reorder_item_' . $orderId, $request->request->get('_token'))) {
+            throw $this->createAccessDeniedException('Invalid CSRF token.');
+        }
+    }
+}

--- a/src/Exception/ReorderException.php
+++ b/src/Exception/ReorderException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Exception;
+
+use DomainException;
+
+class ReorderException extends DomainException
+{
+}

--- a/src/Service/Order/OrderItemReorder.php
+++ b/src/Service/Order/OrderItemReorder.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service\Order;
+
+use App\Exception\ReorderException;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Model\OrderInterface;
+use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Component\Order\Modifier\OrderModifierInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Product\Model\ProductVariantInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+
+final readonly class OrderItemReorder implements OrderItemReorderInterface
+{
+    public function __construct(
+        private CartContextInterface               $cartContext,
+        private OrderItemQuantityModifierInterface $quantityModifier,
+        private OrderModifierInterface             $orderModifier,
+        private OrderProcessorInterface            $orderProcessor,
+        private OrderItemReorderValidatorInterface $orderItemReorderValidator,
+        private FactoryInterface                   $orderItemFactory,
+        private OrderRepositoryInterface           $orderRepository
+    )
+    {
+    }
+
+    public function reorder(OrderItemInterface $orderItem): void
+    {
+        $this->orderItemReorderValidator->validate($orderItem);
+
+        $variant = $orderItem->getVariant();
+        if (null === $variant) {
+            throw new ReorderException('Product variant not available.');
+        }
+
+        $quantity = $orderItem->getQuantity();
+        if ($quantity <= 0) {
+            throw new ReorderException('Quantity must be greater than 0.');
+        }
+
+        $order = $this->cartContext->getCart();
+        $existingItem = $this->findItemInOrderByVariant($order, $variant);
+
+        if ($existingItem) {
+            $this->quantityModifier->modify($existingItem, $existingItem->getQuantity() + $quantity);
+        } else {
+            /** @var OrderItemInterface $newItem */
+            $newItem = $this->orderItemFactory->createNew();
+            $newItem->setVariant($variant);
+
+            $this->quantityModifier->modify($newItem, $quantity);
+            $this->orderModifier->addToOrder($order, $newItem);
+        }
+
+        $this->orderProcessor->process($order);
+        $this->orderRepository->add($order);
+    }
+
+    private function findItemInOrderByVariant(OrderInterface $order, ProductVariantInterface $variant): ?OrderItemInterface
+    {
+        foreach ($order->getItems() as $item) {
+            if ($item->getVariant() === $variant) {
+                return $item;
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Service/Order/OrderItemReorderInterface.php
+++ b/src/Service/Order/OrderItemReorderInterface.php
@@ -1,0 +1,15 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service\Order;
+
+use App\Exception\ReorderException;
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+interface OrderItemReorderInterface
+{
+    /**
+     * @throws ReorderException on failure (e.g. out of stock, not owner)
+     */
+    public function reorder(OrderItemInterface $orderItem): void;
+}

--- a/src/Service/Order/OrderItemReorderValidator.php
+++ b/src/Service/Order/OrderItemReorderValidator.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service\Order;
+
+use App\Exception\ReorderException;
+use Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityCheckerInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+final readonly class OrderItemReorderValidator implements OrderItemReorderValidatorInterface
+{
+    public function __construct(
+        private Security                              $security,
+        private OrderItemAvailabilityCheckerInterface $availabilityChecker,
+    )
+    {
+    }
+
+    public function validate(OrderItemInterface $orderItem): void
+    {
+        $user = $this->security->getUser();
+        $customer = $orderItem->getOrder()?->getCustomer();
+
+        if (!$customer || $customer->getUser() !== $user) {
+            throw new ReorderException('You are not allowed to reorder this item.');
+        }
+
+        if (!$this->availabilityChecker->isReservedStockSufficient($orderItem)) {
+            throw new ReorderException('The requested quantity is no longer available.');
+        }
+    }
+}

--- a/src/Service/Order/OrderItemReorderValidatorInterface.php
+++ b/src/Service/Order/OrderItemReorderValidatorInterface.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Service\Order;
+
+use App\Exception\ReorderException;
+use Sylius\Component\Core\Model\OrderItemInterface;
+
+interface OrderItemReorderValidatorInterface
+{
+/**
+* Validates whether an order item is allowed to be reordered by the current user.
+*
+* @throws ReorderException
+*/
+public function validate(OrderItemInterface $orderItem): void;
+}

--- a/templates/shop/order/show/summary/table/body/actions.html.twig
+++ b/templates/shop/order/show/summary/table/body/actions.html.twig
@@ -1,0 +1,8 @@
+<td class="text-end">
+    <form method="POST" action="{{ path('shop_reorder_item', {'id': hookable_metadata.context.item.id}) }}">
+        <input type="hidden" name="_token" value="{{ csrf_token('reorder_item_' ~ hookable_metadata.context.item.id) }}">
+        <button type="submit" class="btn btn-primary">
+            Reorder
+        </button>
+    </form>
+</td>

--- a/templates/shop/order/show/summary/table/header/actions.html.twig
+++ b/templates/shop/order/show/summary/table/header/actions.html.twig
@@ -1,0 +1,1 @@
+<th class="border-bottom mb-4 pb-4 text-nowrap text-end">Actions</th>

--- a/tests/Service/Order/OrderItemReorderTest.php
+++ b/tests/Service/Order/OrderItemReorderTest.php
@@ -1,0 +1,168 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Service\Order;
+
+use App\Exception\ReorderException;
+use App\Service\Order\OrderItemReorder;
+use App\Service\Order\OrderItemReorderValidatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Repository\OrderRepositoryInterface;
+use Sylius\Component\Order\Context\CartContextInterface;
+use Sylius\Component\Order\Modifier\OrderItemQuantityModifierInterface;
+use Sylius\Component\Order\Modifier\OrderModifierInterface;
+use Sylius\Component\Order\Processor\OrderProcessorInterface;
+use Sylius\Component\Core\Model\ProductVariantInterface;
+use Sylius\Component\Resource\Factory\FactoryInterface;
+use Doctrine\Common\Collections\ArrayCollection;
+
+
+class OrderItemReorderTest extends TestCase
+{
+    private OrderItemReorder $reorderService;
+    private MockObject $cartContext;
+    private MockObject $quantityModifier;
+    private MockObject $orderModifier;
+    private MockObject $orderProcessor;
+    private MockObject $orderItemReorderValidator;
+    private MockObject $orderItemFactory;
+    private MockObject $orderRepository;
+
+    protected function setUp(): void
+    {
+        $this->cartContext = $this->createMock(CartContextInterface::class);
+        $this->quantityModifier = $this->createMock(OrderItemQuantityModifierInterface::class);
+        $this->orderModifier = $this->createMock(OrderModifierInterface::class);
+        $this->orderProcessor = $this->createMock(OrderProcessorInterface::class);
+        $this->orderItemReorderValidator = $this->createMock(OrderItemReorderValidatorInterface::class);
+        $this->orderItemFactory = $this->createMock(FactoryInterface::class);
+        $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
+
+        $this->reorderService = new OrderItemReorder(
+            $this->cartContext,
+            $this->quantityModifier,
+            $this->orderModifier,
+            $this->orderProcessor,
+            $this->orderItemReorderValidator,
+            $this->orderItemFactory,
+            $this->orderRepository
+        );
+    }
+
+    public function testReorderSuccessWithNewItem(): void
+    {
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $newItem = $this->createMock(OrderItemInterface::class);
+
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getQuantity')->willReturn(2);
+
+        $this->cartContext->method('getCart')->willReturn($order);
+        $order->method('getItems')->willReturn(new ArrayCollection([]));
+        $this->orderItemFactory->method('createNew')->willReturn($newItem);
+
+        $this->orderItemReorderValidator->expects($this->once())
+            ->method('validate')
+            ->with($orderItem);
+
+        $newItem->expects($this->once())
+            ->method('setVariant')
+            ->with($variant);
+
+        $this->quantityModifier->expects($this->once())
+            ->method('modify')
+            ->with($newItem, 2);
+
+        $this->orderModifier->expects($this->once())
+            ->method('addToOrder')
+            ->with($order, $newItem);
+
+        $this->orderProcessor->expects($this->once())
+            ->method('process')
+            ->with($order);
+
+        $this->orderRepository->expects($this->once())
+            ->method('add')
+            ->with($order);
+
+        $this->reorderService->reorder($orderItem);
+    }
+
+    public function testReorderSuccessWithExistingItem(): void
+    {
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $existingItem = $this->createMock(OrderItemInterface::class);
+        $variant = $this->createMock(ProductVariantInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getQuantity')->willReturn(2);
+        $existingItem->method('getVariant')->willReturn($variant);
+        $existingItem->method('getQuantity')->willReturn(3);
+
+        $this->cartContext->method('getCart')->willReturn($order);
+        $order->method('getItems')->willReturn(new ArrayCollection([$existingItem]));
+
+        $this->orderItemReorderValidator->expects($this->once())
+            ->method('validate')
+            ->with($orderItem);
+
+        $this->quantityModifier->expects($this->once())
+            ->method('modify')
+            ->with($existingItem, 5); // 3 + 2
+
+        $this->orderProcessor->expects($this->once())
+            ->method('process')
+            ->with($order);
+
+        $this->orderRepository->expects($this->once())
+            ->method('add')
+            ->with($order);
+
+        $this->reorderService->reorder($orderItem);
+    }
+
+    public function testReorderFailsWhenValidatorThrowsException(): void
+    {
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $this->orderItemReorderValidator->method('validate')
+            ->willThrowException(new ReorderException('Validation error'));
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('Validation error');
+
+        $this->reorderService->reorder($orderItem);
+    }
+
+    public function testReorderFailsWhenVariantIsNull(): void
+    {
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $orderItem->method('getVariant')->willReturn(null);
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('Product variant not available.');
+
+        $this->reorderService->reorder($orderItem);
+    }
+
+    public function testReorderFailsWhenQuantityIsZero(): void
+    {
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $variant = $this->createMock(ProductVariantInterface::class);
+
+        $orderItem->method('getVariant')->willReturn($variant);
+        $orderItem->method('getQuantity')->willReturn(0);
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('Quantity must be greater than 0.');
+
+        $this->reorderService->reorder($orderItem);
+    }
+}

--- a/tests/Service/Order/OrderItemReorderValidatorTest.php
+++ b/tests/Service/Order/OrderItemReorderValidatorTest.php
@@ -1,0 +1,135 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Service\Order;
+
+use App\Exception\ReorderException;
+use App\Service\Order\OrderItemReorderValidator;
+use App\Service\Order\OrderItemReorderValidatorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Sylius\Component\Core\Inventory\Checker\OrderItemAvailabilityCheckerInterface;
+use Sylius\Component\Core\Model\CustomerInterface;
+use Sylius\Component\Core\Model\OrderInterface;
+use Sylius\Component\Core\Model\OrderItemInterface;
+use Sylius\Component\Core\Model\ShopUserInterface;
+use Symfony\Bundle\SecurityBundle\Security;
+
+class OrderItemReorderValidatorTest extends TestCase
+{
+    private OrderItemReorderValidator $validator;
+    private MockObject $security;
+    private MockObject $availabilityChecker;
+
+    protected function setUp(): void
+    {
+        $this->security = $this->createMock(Security::class);
+        $this->availabilityChecker = $this->createMock(OrderItemAvailabilityCheckerInterface::class);
+
+        $this->validator = new OrderItemReorderValidator(
+            $this->security,
+            $this->availabilityChecker
+        );
+    }
+
+    public function testValidateSuccessful(): void
+    {
+        $user = $this->createMock(ShopUserInterface::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $this->security->method('getUser')->willReturn($user);
+        $orderItem->method('getOrder')->willReturn($order);
+        $order->method('getCustomer')->willReturn($customer);
+        $customer->method('getUser')->willReturn($user);
+        $this->availabilityChecker->method('isReservedStockSufficient')
+            ->with($orderItem)
+            ->willReturn(true);
+
+        $this->validator->validate($orderItem);
+        $this->assertTrue(true);
+    }
+
+    public function testValidateFailsWhenUserDoesNotMatch(): void
+    {
+        $currentUser = $this->createMock(ShopUserInterface::class);
+        $orderUser = $this->createMock(ShopUserInterface::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $this->security->method('getUser')->willReturn($currentUser);
+        $orderItem->method('getOrder')->willReturn($order);
+        $order->method('getCustomer')->willReturn($customer);
+        $customer->method('getUser')->willReturn($orderUser); // Different user
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('You are not allowed to reorder this item.');
+
+        $this->validator->validate($orderItem);
+    }
+
+    public function testValidateFailsWhenNoCurrentUser(): void
+    {
+        $orderItem = $this->createMock(OrderItemInterface::class);
+        $this->security->method('getUser')->willReturn(null);
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('You are not allowed to reorder this item.');
+
+        $this->validator->validate($orderItem);
+    }
+
+    public function testValidateFailsWhenOrderIsNull(): void
+    {
+        $user = $this->createMock(ShopUserInterface::class);
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $this->security->method('getUser')->willReturn($user);
+        $orderItem->method('getOrder')->willReturn(null);
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('You are not allowed to reorder this item.');
+
+        $this->validator->validate($orderItem);
+    }
+
+    public function testValidateFailsWhenCustomerIsNull(): void
+    {
+        $user = $this->createMock(ShopUserInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $this->security->method('getUser')->willReturn($user);
+        $orderItem->method('getOrder')->willReturn($order);
+        $order->method('getCustomer')->willReturn(null);
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('You are not allowed to reorder this item.');
+
+        $this->validator->validate($orderItem);
+    }
+
+    public function testValidateFailsWhenStockIsInsufficient(): void
+    {
+        $user = $this->createMock(ShopUserInterface::class);
+        $customer = $this->createMock(CustomerInterface::class);
+        $order = $this->createMock(OrderInterface::class);
+        $orderItem = $this->createMock(OrderItemInterface::class);
+
+        $this->security->method('getUser')->willReturn($user);
+        $orderItem->method('getOrder')->willReturn($order);
+        $order->method('getCustomer')->willReturn($customer);
+        $customer->method('getUser')->willReturn($user);
+
+        $this->availabilityChecker->method('isReservedStockSufficient')
+            ->with($orderItem)
+            ->willReturn(false);
+
+        $this->expectException(ReorderException::class);
+        $this->expectExceptionMessage('The requested quantity is no longer available.');
+
+        $this->validator->validate($orderItem);
+    }
+}


### PR DESCRIPTION
Add Reorder Button for Customer Order Items

This PR allows customers to reorder individual items from previous orders in the account order view.

Key Features:

- Twig Hooks: Added “Reorder” button using sylius_shop.shared.order.show.summary.table.body and column header.
- Controller: Handles /reorder/{id} POST with CSRF and authentication checks.
- OrderItemReorder: Adds item to cart (existing or new).
- OrderItemReorderValidator: Validates user ownership and stock.
- Flash Messages: Success/error feedback on reorder.
- Unit Tests: Coverage for service and validator (success, invalid variant, unauthorized, out of stock).


Built using Sylius services and extension points with no core modifications.