### PR TITLE
Fix doctrine cache on production

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -27,27 +27,14 @@ when@prod: &doctrine_prod
             entity_managers:
                 default:
                     metadata_cache_driver:
-                        type: service
-                        id: doctrine.system_cache_provider
+                        type: pool
+                        pool: doctrine.system_cache_pool
                     query_cache_driver:
-                        type: service
-                        id: doctrine.system_cache_provider
+                        type: pool
+                        pool: doctrine.system_cache_pool
                     result_cache_driver:
-                        type: service
-                        id: doctrine.result_cache_provider
-    services:
-        doctrine.result_cache_provider:
-            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
-            public: false
-            factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
-            arguments:
-                - '@doctrine.result_cache_pool'
-        doctrine.system_cache_provider:
-            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
-            public: false
-            factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
-            arguments:
-                - '@doctrine.system_cache_pool'
+                        type: pool
+                        pool: doctrine.result_cache_pool
     framework:
         cache:
             pools:


### PR DESCRIPTION
`Doctrine\Common\Cache\Psr6\DoctrineProvider` is not available any more in latest doctrine