### PR TITLE
Fix doctrine cache on production 2.1

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -27,27 +27,14 @@ when@prod: &doctrine_prod
             entity_managers:
                 default:
                     metadata_cache_driver:
-                        type: service
-                        id: doctrine.system_cache_provider
+                        type: pool
+                        pool: doctrine.system_cache_pool
                     query_cache_driver:
-                        type: service
-                        id: doctrine.system_cache_provider
+                        type: pool
+                        pool: doctrine.system_cache_pool
                     result_cache_driver:
-                        type: service
-                        id: doctrine.result_cache_provider
-    services:
-        doctrine.result_cache_provider:
-            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
-            public: false
-            factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
-            arguments:
-                - '@doctrine.result_cache_pool'
-        doctrine.system_cache_provider:
-            class: Doctrine\Common\Cache\Psr6\DoctrineProvider
-            public: false
-            factory: [ 'Doctrine\Common\Cache\Psr6\DoctrineProvider', 'wrap' ]
-            arguments:
-                - '@doctrine.system_cache_pool'
+                        type: pool
+                        pool: doctrine.result_cache_pool
     framework:
         cache:
             pools:

--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -9,32 +9,28 @@ doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
     orm:
-        auto_generate_proxy_classes: '%kernel.debug%'
-        entity_managers:
-            default:
-                auto_mapping: true
-                mappings:
-                    App:
-                        is_bundle: false
-                        type: attribute
-                        dir: '%kernel.project_dir%/src/Entity'
-                        prefix: 'App\Entity'
-                        alias: App
+        auto_generate_proxy_classes: true
+        auto_mapping: true
+        mappings:
+            App:
+                is_bundle: false
+                type: attribute
+                dir: '%kernel.project_dir%/src/Entity'
+                prefix: 'App\Entity'
+                alias: App
 
 when@prod: &doctrine_prod
     doctrine:
         orm:
-            entity_managers:
-                default:
-                    metadata_cache_driver:
-                        type: pool
-                        pool: doctrine.system_cache_pool
-                    query_cache_driver:
-                        type: pool
-                        pool: doctrine.system_cache_pool
-                    result_cache_driver:
-                        type: pool
-                        pool: doctrine.result_cache_pool
+            auto_generate_proxy_classes: false
+            proxy_dir: '%kernel.build_dir%/doctrine/orm/Proxies'
+            query_cache_driver:
+                type: pool
+                pool: doctrine.system_cache_pool
+            result_cache_driver:
+                type: pool
+                pool: doctrine.result_cache_pool
+
     framework:
         cache:
             pools:


### PR DESCRIPTION
`Doctrine\Common\Cache\Psr6\DoctrineProvider` is not available any more in latest doctrine

Fixes: https://github.com/Sylius/Sylius-Standard/issues/1151