### PR TITLE
Enable cache busting & subresource integrity in Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,10 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .configureFilenames({
+      js:  'js/[name].[contenthash:8].js',
+      css: 'css/[name].[contenthash:8].css',
+    })
     .enableSassLoader()
     // .enableStimulusBridge(path.resolve(__dirname, './assets/shop/controllers.json'))
     // remove the following line if you don't want to add automatically controllers provided by plugins
@@ -66,6 +70,10 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .configureFilenames({
+      js:  'js/[name].[contenthash:8].js',
+      css: 'css/[name].[contenthash:8].css',
+    })
     .enableSassLoader()
     //.enableStimulusBridge(path.resolve(__dirname, './assets/admin/controllers.json'))
     // remove the following line if you don't want to add automatically controllers provided by plugins

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,7 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .enableIntegrityHashes(Encore.isProduction())
     .configureFilenames({
       js:  'js/[name].[contenthash:8].js',
       css: 'css/[name].[contenthash:8].css',
@@ -70,6 +71,7 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .enableIntegrityHashes(Encore.isProduction())
     .configureFilenames({
       js:  'js/[name].[contenthash:8].js',
       css: 'css/[name].[contenthash:8].css',


### PR DESCRIPTION
This update enables cache busting for all CSS and JS assets by appending a unique hash to their filenames. As a result, browsers are forced to load the latest versions of these files after each application rebuild, preventing stale content from being served from cache.

Additionally, Subresource Integrity (SRI) is enabled to ensure that loaded files match their expected content, improving security when serving assets from different sources.