### PR TITLE
Enable cache busting & subresource integrity in Webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,10 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .configureFilenames({
+      js:  'js/[name].[contenthash:8].js',
+      css: 'css/[name].[contenthash:8].css',
+    })
     .enableSassLoader()
     .enableStimulusBridge(path.resolve(__dirname, './assets/shop/controllers.json'))
 ;
@@ -55,6 +59,10 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .configureFilenames({
+      js:  'js/[name].[contenthash:8].js',
+      css: 'css/[name].[contenthash:8].css',
+    })
     .enableSassLoader()
     .enableStimulusBridge(path.resolve(__dirname, './assets/admin/controllers.json'))
 ;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,6 +27,7 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .enableIntegrityHashes(Encore.isProduction())
     .configureFilenames({
       js:  'js/[name].[contenthash:8].js',
       css: 'css/[name].[contenthash:8].css',
@@ -59,6 +60,7 @@ Encore
     .cleanupOutputBeforeBuild()
     .enableSourceMaps(!Encore.isProduction())
     .enableVersioning(Encore.isProduction())
+    .enableIntegrityHashes(Encore.isProduction())
     .configureFilenames({
       js:  'js/[name].[contenthash:8].js',
       css: 'css/[name].[contenthash:8].css',


### PR DESCRIPTION
This update enables cache busting for all CSS and JS assets by appending a unique hash to their filenames. As a result, browsers are forced to load the latest versions of these files after each application rebuild, preventing stale content from being served from cache.

Additionally, Subresource Integrity (SRI) is enabled to ensure that loaded files match their expected content, improving security when serving assets from different sources.