### PR TITLE
Bump minimum PHP requirement to 8.3

### DIFF
--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -89,10 +89,6 @@ jobs:
                         ${{ steps.composer-cache.outputs.dir }}
                     key: ${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}
 
-            -   name: "Require ext-random"
-                if: matrix.php == '8.3'
-                run: composer require ext-random --no-update --no-scripts --no-interaction
-
             -   name: "Install dependencies"
                 run: composer update --no-interaction --no-scripts
 

--- a/.github/workflows/ci_static-checks.yaml
+++ b/.github/workflows/ci_static-checks.yaml
@@ -90,7 +90,7 @@ jobs:
                     key: ${{ github.run_id }}-${{ runner.os }}-${{ hashFiles('composer.json') }}-symfony-${{ matrix.symfony }}
 
             -   name: "Require ext-random"
-                if: matrix.php == '8.2'
+                if: matrix.php == '8.3'
                 run: composer require ext-random --no-update --no-scripts --no-interaction
 
             -   name: "Install dependencies"

--- a/.github/workflows/matrix.json
+++ b/.github/workflows/matrix.json
@@ -3,25 +3,25 @@
     "static-checks": {
       "include": [
         {
-          "php": "8.2",
+          "php": "8.3",
           "symfony": "^6.4"
         },
         {
-          "php": "8.3",
-          "symfony": "^7.1"
+          "php": "8.4",
+          "symfony": "^7.3"
         }
       ]
     },
     "e2e-mysql": {
       "include": [
         {
-          "php": "8.2",
+          "php": "8.3",
           "symfony": "^6.4",
           "mysql": "8.4"
         },
         {
-          "php": "8.3",
-          "symfony": "^7.1",
+          "php": "8.4",
+          "symfony": "^7.3",
           "mysql": "8.4"
         }
       ]

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         }
     ],
     "require": {
-        "php": "^8.2",
+        "php": "^8.3",
         "sylius/mollie-plugin": "^3.0",
         "sylius/paypal-plugin": "^2.0",
         "sylius/sylius": "^2.1",


### PR DESCRIPTION
## Rationale

This PR bumps the minimum PHP requirement from 8.2 to 8.3 to align with the Docker configuration (`compose.yml` already uses PHP 8.3) and prepare for the future.

## Why PHP 8.3?

- **PHP 8.2 EOL approaching**: Active support ends December 2025, security support ends December 2026
- **Current stable version**: PHP 8.3 is the current stable release with better performance and features
- **Consistency**: `compose.yml` already uses `ghcr.io/sylius/sylius-php:8.3-alpine`
- **Best practice**: New application templates should target current PHP versions

This ensures a consistent development environment and encourages adoption of modern PHP versions for new projects.

## CI Updates

Also updates the CI matrix to test against PHP 8.3/8.4 with Symfony ^7.3. Removed the obsolete `ext-random` workaround that was previously needed for PHP 8.2, as the extension is bundled with PHP core since 8.2 and no longer requires explicit declaration.