### PR TITLE
Enable Symfony Flex contrib recipes by default

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,7 @@
             "dev-main": "2.1-dev"
         },
         "symfony": {
-            "allow-contrib": false,
+            "allow-contrib": true,
             "require": "^7.2",
             "endpoint": [
                 "https://api.github.com/repos/Sylius/SyliusRecipes/contents/index.json?ref=flex/main",


### PR DESCRIPTION
Changes `allow-contrib` from `false` to `true` in `composer.json` to enable automatic installation of Symfony Flex recipes from the contrib repository.

Currently, Sylius Standard ships with `allow-contrib: false`, which prevents Symfony Flex from automatically applying recipes from `symfony/recipes-contrib`. This causes issues when installing community packages that rely on contrib recipes, as their configuration files and bundle registrations are silently ignored during `composer require`.

This change enables contrib recipes by default because:
- Many Sylius ecosystem packages already use contrib recipes (e.g., `sylius/mollie-plugin`, `sylius/paypal-plugin`, `liip/imagine-bundle`)
- Contrib recipes are community-maintained but still validated and safe to use
- Symfony Flex previously prompted users interactively, but with `allow-contrib: false` it silently ignores recipes, creating a confusing experience
- Having this disabled by default forces users to manually configure every package, defeating the purpose of Flex recipes

Refs:
- https://symfony.com/doc/current/setup/flex_private_recipes.html
- https://fabien.potencier.org/symfony4-contributing-recipes.html
- https://github.com/symfony/recipes-contrib