### PR TITLE
Update Rector configuration to new API syntax

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -4,11 +4,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 
-return static function (RectorConfig $rectorConfig): void {
-    $rectorConfig->importNames();
-    $rectorConfig->removeUnusedImports();
-    $rectorConfig->import(__DIR__ . '/vendor/sylius/sylius-rector/config/config.php');
-    $rectorConfig->paths([
-        __DIR__ . '/src'
+return RectorConfig::configure()
+    ->withPaths([
+        __DIR__ . '/src',
     ]);
-};


### PR DESCRIPTION
Migrates rector.php from legacy callback-style configuration to the new RectorConfig::configure() API.

The old callback syntax is deprecated in favor of the fluent API introduced in recent Rector versions.