### PR TITLE
Add rector/extension-installer to composer allow-plugins

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,12 +70,13 @@
         },
         "sort-packages": true,
         "allow-plugins": {
-            "symfony/flex": true,
             "dealerdirect/phpcodesniffer-composer-installer": false,
             "php-http/discovery": false,
             "phpstan/extension-installer": false,
-            "symfony/thanks": false,
-            "symfony/runtime": true
+            "rector/extension-installer": true,
+            "symfony/flex": true,
+            "symfony/runtime": true,
+            "symfony/thanks": false
         }
     },
     "extra": {


### PR DESCRIPTION
Enables the rector/extension-installer Composer plugin, which is required for Sylius Rector to properly load its plugin installation rules.

Changes:
- Add rector/extension-installer to allow-plugins configuration
- Sort allow-plugins alphabetically for consistency
