### PR TITLE
Add Rector scripts to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -117,6 +117,8 @@
             "@php bin/console sylius:inform-about-gus --ansi",
             "@php bin/console sylius:show-plus-info --ansi"
         ],
+        "rector-dry-run": "vendor/bin/rector process --dry-run",
+        "rector-apply": "vendor/bin/rector process",
         "auto-scripts": {
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"


### PR DESCRIPTION
Adds convenience scripts for running Rector in dry-run and apply modes.

- `rector-dry-run`: runs Rector without making changes
- `rector-apply`: applies Rector refactorings

Makes it easier to run Rector commands without typing the full vendor path.