### PR TITLE
Add `config/reference.php` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 /.env.*.local
 /.env.local
 /.env.local.php
+/config/reference.php
 /public/bundles
 /var/
 /vendor/


### PR DESCRIPTION
This file is automatically generated by symfony/framework-bundle in debug mode to help IDEs with autocompletion for PHP configuration. Since it's generated on the fly and may vary between environments, it makes sense to keep it out of version control.