### PR TITLE
Use APP_ENV instead of ENV in Docker Compose config

### DIFF
--- a/compose.override.dist.yml
+++ b/compose.override.dist.yml
@@ -7,7 +7,7 @@ services:
                 condition: service_healthy
         environment:
             # You can move these environment variables to your .env.local file
-            APP_ENV: ${ENV:-prod}
+            APP_ENV: ${APP_ENV:-dev}
             APP_SECRET: EDITME
             DATABASE_URL: "mysql://root@mysql/sylius_%kernel.environment%"
             MAILER_DSN: smtp://mailhog:1025


### PR DESCRIPTION
Changes `APP_ENV: ${ENV:-prod}` to `APP_ENV: ${APP_ENV:-dev}` in `compose.override.dist.yml`.

The previous configuration was confusing because:
- It used a non-standard `ENV` variable instead of Symfony's `APP_ENV`
- Setting `APP_ENV=dev` in `.env` had no effect on Docker containers
- The default `prod` made no sense for a development setup (with xdebug, fixuid, volumes)

Now `APP_ENV` from `.env` is respected and defaults to `dev`.