### PR TITLE
Drop Symfony 6.4 support, require Symfony 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,9 +28,9 @@
         "sylius/mollie-plugin": "^3.2",
         "sylius/paypal-plugin": "^2.0",
         "sylius/sylius": "^2.1",
-        "symfony/dotenv": "^6.4 || ^7.4",
+        "symfony/dotenv": "^7.4",
         "symfony/flex": "^2.10",
-        "symfony/runtime": "^6.4 || ^7.4"
+        "symfony/runtime": "^7.4"
     },
     "require-dev": {
         "behat/behat": "^3.2",
@@ -57,12 +57,12 @@
         "sylius-labs/coding-standard": "^4.5",
         "sylius-labs/suite-tags-extension": "~0.2",
         "sylius/sylius-rector": "^3.7",
-        "symfony/browser-kit": "^6.4 || ^7.4",
+        "symfony/browser-kit": "^7.4",
         "symfony/contracts": "^3.6",
-        "symfony/debug-bundle": "^6.4 || ^7.4",
-        "symfony/http-client": "^6.4 || ^7.4",
-        "symfony/intl": "^6.4 || ^7.4",
-        "symfony/web-profiler-bundle": "^6.4 || ^7.4"
+        "symfony/debug-bundle": "^7.4",
+        "symfony/http-client": "^7.4",
+        "symfony/intl": "^7.4",
+        "symfony/web-profiler-bundle": "^7.4"
     },
     "config": {
         "preferred-install": {


### PR DESCRIPTION
Sylius 2.1 requires Symfony 7.4. This updates `composer.json` to drop Symfony 6.4 support and removes the `symfony/dotenv` dependency which was not needed.

- Remove `^6.4 || ` version constraints from Symfony packages
- Remove `symfony/dotenv` (unused)
- Require only `^7.4` for all Symfony dependencies