### PR TITLE
[Maintenance] Bump Sylius to ^2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -82,7 +82,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-2.1": "2.1.x-dev"
+            "dev-2.2": "2.2.x-dev"
         },
         "symfony": {
             "allow-contrib": true,

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "php": "^8.3",
         "sylius/mollie-plugin": "^3.2",
         "sylius/paypal-plugin": "^2.0",
-        "sylius/sylius": "^2.1",
+        "sylius/sylius": "^2.2",
         "symfony/dotenv": "^7.4",
         "symfony/flex": "^2.10",
         "symfony/runtime": "^7.4"


### PR DESCRIPTION
Bumps `sylius/sylius` requirement from `^2.1` to `^2.2` and updates the branch alias accordingly.