### PR TITLE
Fix Doctrine transactions with Postgres

### DIFF
--- a/config/packages/doctrine.yaml
+++ b/config/packages/doctrine.yaml
@@ -8,6 +8,7 @@ parameters:
 doctrine:
     dbal:
         url: '%env(resolve:DATABASE_URL)%'
+        use_savepoints: true
     orm:
         auto_generate_proxy_classes: true
         auto_mapping: true


### PR DESCRIPTION
It's removed on dbal 4, but for now we need this change for postgres usage.
Migrations are broken without this option enabled.