### PR TITLE
Add sylius/sylius-ai-dev-tools as a suggested package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,9 @@
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         }
     },
+    "suggest": {
+        "sylius/sylius-ai-dev-tools": "Dev-only AI tooling pack for Sylius: bundles Mate extension and Sylius skills."
+    },
     "replace": {
         "symfony/polyfill-apcu": "*",
         "symfony/polyfill-ctype": "*",


### PR DESCRIPTION
Adds the new sylius/sylius-ai-dev-tools package as a Composer suggestion.

It is a dev-only AI tooling pack that bundles the Mate extension and Sylius
skills. Exposing it via `suggest` makes it discoverable for developers, who
can opt in with `composer require --dev sylius/sylius-ai-dev-tools`.