### PR TITLE
Remove unused Stripe configuration from .env and config/packages

### DIFF
--- a/.env
+++ b/.env
@@ -48,7 +48,3 @@ SYLIUS_PAYMENT_ENCRYPTION_KEY_PATH=%kernel.project_dir%/config/encryption/test.k
 # See https://symfony.com/doc/current/routing.html#generating-urls-in-commands
 DEFAULT_URI=http://localhost
 ###< symfony/routing ###
-
-###> stripe/stripe-php ###
-STRIPE_SECRET_KEY=sk_test_***
-###< stripe/stripe-php ###

--- a/config/packages/stripe.yaml
+++ b/config/packages/stripe.yaml
@@ -1,7 +1,0 @@
-services:
-    stripe.client:
-        class: 'Stripe\StripeClient'
-        arguments:
-            - '%env(STRIPE_SECRET_KEY)%'
-
-    Stripe\StripeClient: '@stripe.client'


### PR DESCRIPTION
This pull request removes the Stripe integration configuration from the project. The main changes are the removal of the Stripe secret key from the environment variables and the deletion of the Stripe client service configuration.

Removed Stripe integration:

* Deleted the `STRIPE_SECRET_KEY` environment variable from the `.env` file, removing sensitive Stripe credentials from the configuration.
* Removed the `stripe.client` service definition and related configuration from `config/packages/stripe.yaml`, which disables the Stripe client in the application.