### PR TITLE
Move MySQL depends_on out of base compose file

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,6 @@
 services:
     php:
         image: ghcr.io/sylius/sylius-php:8.3-alpine
-        depends_on:
-            mysql:
-                condition: service_healthy
     mysql:
         image: mysql:8.4
         platform: linux/amd64


### PR DESCRIPTION
The php service required mysql via depends_on in compose.yml, forcing MySQL even when it is not used. This dependency belongs in compose.override.dist.yml, which make init copies and applies.